### PR TITLE
Updates settings in settings doc

### DIFF
--- a/src/install/deploySteps.js
+++ b/src/install/deploySteps.js
@@ -112,6 +112,25 @@ module.exports = (apps, mode, deployDoc) => {
       });
   };
 
+  const updateSettings = oldSettings => {
+    if (!oldSettings) {
+      return debug('No settings found on primary ddoc - doing nothing');
+    }
+    return DB.app.get('settings')
+      .catch(err => {
+        if (err.status !== 404) {
+          throw err;
+        }
+        debug('No settings doc found - creating a new one');
+        return { _id: 'settings' };
+      })
+      .then(doc => {
+        doc.settings = oldSettings;
+        return DB.app.put(doc);
+      })
+      .then(() => debug('Settings doc updated'));
+  };
+
   const deployPrimaryDdoc = primaryDdoc => {
     debug(`Primary ddoc: ${primaryDdoc._id}`);
     debug('Checking to see if primary exists already');
@@ -126,18 +145,17 @@ module.exports = (apps, mode, deployDoc) => {
       })
       .then(deployedDdoc => {
         if (deployedDdoc) {
-          debug('It does, copying config to staged ddoc before writing');
-          primaryDdoc.app_settings = deployedDdoc.app_settings;
+          debug('It does, copying config to settings doc before overwriting');
           primaryDdoc._rev = deployedDdoc._rev;
+          return updateSettings(deployedDdoc.app_settings);
         } else {
-          debug('It does not');
+          debug('It does not, preparing ddoc for fresh install');
           delete primaryDdoc._rev;
         }
-
-        debug('Writing primary ddoc');
-        return DB.app.put(primaryDdoc)
-          .then(() => debug('Primary ddoc written'));
-      });
+      })
+      .then(() => debug('Writing primary ddoc'))
+      .then(() => DB.app.put(primaryDdoc))
+      .then(() => debug('Primary ddoc written'));
   };
 
   const deployStagedDdocs = () => {

--- a/src/install/deploySteps.js
+++ b/src/install/deploySteps.js
@@ -114,7 +114,7 @@ module.exports = (apps, mode, deployDoc) => {
 
   const updateSettings = oldSettings => {
     if (!oldSettings) {
-      return debug('No settings found on primary ddoc - doing nothing');
+      return;
     }
     return DB.app.get('settings')
       .catch(err => {
@@ -145,7 +145,7 @@ module.exports = (apps, mode, deployDoc) => {
       })
       .then(deployedDdoc => {
         if (deployedDdoc) {
-          debug('It does, copying config to settings doc before overwriting');
+          debug('It does, preparing ddoc for upgrade');
           primaryDdoc._rev = deployedDdoc._rev;
           return updateSettings(deployedDdoc.app_settings);
         } else {

--- a/tests/install.js
+++ b/tests/install.js
@@ -202,24 +202,28 @@ describe('Installation flow', () => {
           });
       });
       it('Deploys primary ddoc when one existed before, copying app settings', () => {
-        DB.app.get.resolves({
+        DB.app.get.withArgs('_design/medic').resolves({
           _id: '_design/medic',
           _rev: '1-existingDdoc',
           app_settings: {
             some: 'settings'
           }
         });
+        DB.app.get.withArgs('settings').rejects({ status: 404 });
         DB.app.put.resolves();
 
         return steps._deployPrimaryDdoc(primaryDdoc)
           .then(() => {
-            DB.app.put.callCount.should.equal(1);
+            DB.app.put.callCount.should.equal(2);
             DB.app.put.args[0][0].should.deep.equal({
+              _id: 'settings',
+              settings: {
+                some: 'settings'
+              }
+            });
+            DB.app.put.args[1][0].should.deep.equal({
               _id: '_design/medic',
               _rev: '1-existingDdoc',
-              app_settings: {
-                some: 'settings'
-              },
               staged: true
             });
           });


### PR DESCRIPTION
We now store settings in a new doc rather than in the ddoc. Horti
needs to create or update the settings doc before blowing away the
ddoc app_settings.

medic/medic-webapp#4541