### PR TITLE
Start apps first

### DIFF
--- a/src/daemon.js
+++ b/src/daemon.js
@@ -98,14 +98,17 @@ module.exports = {
 
     const apps = appUtils(mode.start, mode.stop);
 
-    let bootAction;
-    if (module.exports._newDeployment(deployDoc)) {
-      bootAction = module.exports._performDeployment(deployDoc, mode, apps, true);
-    } else {
-      bootAction = apps.start();
+    let bootActions = Promise.resolve();
+
+    if (mode.startAppsOnStartup) {
+      bootActions = bootActions.then(() => apps.start());
     }
 
-    return bootAction.then(() => module.exports._watchForDeployments(mode, apps));
+    if (module.exports._newDeployment(deployDoc)) {
+      bootActions = bootActions.then(() => module.exports._performDeployment(deployDoc, mode, apps, true));
+    }
+
+    return bootActions.then(() => module.exports._watchForDeployments(mode, apps));
   },
   _newDeployment: newDeployment,
   _performDeployment: performDeployment,

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,8 @@ const MODES = {
     deployments: '/srv/software',
     start: ['sudo', '-n', '/boot/svc-start', '{{app}}' ],
     stop: ['sudo', '-n', '/boot/svc-stop', '{{app}}' ],
+    // This starting will be managed by the medicos supervisor. In this
+    // deployment mode we only control the restarting of apps
     startAppsOnStartup: false,
   },
 };


### PR DESCRIPTION
Depending on mode, start apps before attmepting to handle any existing
deployments. This ensues a fast usable boot if there is an ongoing
deployment.