### PR TITLE
Horti learns how to shutdown safely

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -843,9 +843,12 @@
       }
     },
     "lockfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
-      "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "requires": {
+        "signal-exit": "^3.0.2"
+      }
     },
     "lodash": {
       "version": "3.7.0",
@@ -1642,6 +1645,11 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,14 @@
     "debug": "^3.1.0",
     "decompress": "^4.2.0",
     "fs-extra": "^3.0.1",
-    "lockfile": "^1.0.3",
+    "lockfile": "^1.0.4",
     "minimist": "^1.2.0",
     "pouchdb-adapter-http": "^6.2.0",
     "pouchdb-core": "^6.2.0",
     "pouchdb-mapreduce": "^6.2.0",
     "request": "^2.85.0",
-    "request-promise-native": "^1.0.5"
+    "request-promise-native": "^1.0.5",
+    "signal-exit": "^3.0.2"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/src/apps.js
+++ b/src/apps.js
@@ -34,10 +34,16 @@ module.exports = (startCmd, stopCmd) => {
           .then(() => debug(`Stopped ${app}.`)),
         Promise.resolve());
 
+  const stopSync = () => {
+    APPS.forEach(app => {
+      execForApp(stopCmd, app);
+    });
+  };
 
   return {
     APPS: APPS,
     start: startApps,
     stop: stopApps,
+    stopSync: stopSync,
   };
 };

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -18,8 +18,7 @@ const ACTIONS = {
   COMPLETE: 'complete'
 };
 
-const appUtils = require('./apps'),
-      DB = require('./dbs'),
+const DB = require('./dbs'),
       install = require('./install'),
       fatality = require('./fatality');
 
@@ -102,14 +101,12 @@ const watchForDeployments = (mode, apps) => {
 };
 
 module.exports = {
-  init: (deployDoc, mode) => {
+  init: (deployDoc, mode, apps) => {
     info('Initiating horticulturalist daemon');
-
-    const apps = appUtils(mode.start, mode.stop);
 
     let bootActions = Promise.resolve();
 
-    if (mode.startAppsOnStartup) {
+    if (mode.manageAppLifecycle) {
       bootActions = bootActions.then(() => apps.start());
     }
 

--- a/src/fatality.js
+++ b/src/fatality.js
@@ -1,10 +1,8 @@
-const lockfile = require('./lockfile'),
-      log = require('./log');
+const log = require('./log');
 
 module.exports = err => {
   log.error('********FATAL********');
   log.error(err);
 
-  lockfile.release()
-    .then(() => process.exit(1));
+  process.exit(1);
 };

--- a/src/install/deploySteps.js
+++ b/src/install/deploySteps.js
@@ -3,8 +3,7 @@ const decompress = require('decompress'),
       path = require('path');
 
 const { info, debug } = require('../log'),
-      DB = require('../dbs'),
-      lockfile = require('../lockfile');
+      DB = require('../dbs');
 
 const utils = require('../utils');
 
@@ -180,7 +179,7 @@ module.exports = (apps, mode, deployDoc) => {
     const changedApps = getChangedApps(ddoc);
     const appsToDeploy = changedApps.length;
 
-    return lockfile.wait()
+    return Promise.resolve()
       .then(() => {
         if (appsToDeploy) {
           return Promise.resolve()
@@ -208,7 +207,6 @@ module.exports = (apps, mode, deployDoc) => {
       })
 
       .then(() => (appsToDeploy || firstRun) && startApps())
-      .then(() => lockfile.release())
       .then(() => true);
   };
 

--- a/src/lockfile.js
+++ b/src/lockfile.js
@@ -9,16 +9,6 @@ function lockFileExists() {
   return lockfile.checkSync(LOCK_FILE);
 }
 
-function releaseLock() {
-  return new Promise(resolve =>
-    lockfile.unlock(LOCK_FILE, err => {
-      if(err) {
-        console.error(err);
-        process.exit(1);
-      } else resolve();
-    }));
-}
-
 const waitForLock = () =>
   new Promise((resolve, reject) => {
     lockfile.lock(LOCK_FILE, err => {
@@ -30,6 +20,5 @@ const waitForLock = () =>
 module.exports = {
   exists: lockFileExists,
   path: () => path.resolve(LOCK_FILE),
-  release: releaseLock,
   wait: waitForLock,
 };


### PR DESCRIPTION
Horti now shuts down cleanly in the way it should dependent on platform:
 - On medic-os it just handles cleaning up after itself
 - Elsewhere it also tries to kill apps it started

We also now use the lockfile correctly, covering the running of the
whole application instead of just deploying.

Updated lockfile to the latest version which more correctly catches
exits to clean up after itself. We no longer need to attempt to clean
up the lock ourselves.

medic/medic-webapp#4562