### PR TITLE
Support all deploy actions from the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ For more detailed documentation on how to start Medic using Horticulturalist, [s
 
 ## From `npm`
 
-    npm install horticulturalist
-    COUCH_URL=http://admin:pass@localhost:5984/medic horti --local --bootstrap
+    npm install -g horticulturalist
+    COUCH_URL=http://admin:pass@localhost:5984/medic horti --local --install
 
 ## From source
 
@@ -31,12 +31,17 @@ Pick one mode to run in:
         Only of interest to those who deploy using MedicOS. Deploys apps using
         the MedicOS daemon.
 
-Additional options:
+You can also specify a deployment action to perform:
 
-    --bootstrap[=buildname|@type]
+    --install[=buildname|@type]
         Download the latest master (or specified) build and deploy to the
         local db at startup. Buildname can either be an exact build name (eg
         'master'), or @type for the latest of that type (eg @release or @beta).
-    --only-bootstrap[=buildname|@type]
-        Like above this bootstraps to the given build, but doesn't start the 
-        daemon or deploy any applications
+    --stage[=buildname|@type]
+        The same as install, but prepares a deploy and does not actually 
+        install and deploy it.
+    --complete-install
+        Completes a staged install or errors if one does not exist.
+    --no-daemon
+        Does not start node modules or watch for new installations, but does 
+        perform one of the above actions if specified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,15 @@
         "type-detect": "^4.0.0"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "attempt-x": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.3.tgz",
+      "integrity": "sha512-y/+ek8IjxVpTbj/phC87jK5YRhlP5Uu7FlQdCmYuut1DTjNruyrGqUWi5bcX1VKsQX1B0FX16A1hqHomKpHv3A=="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -134,6 +139,11 @@
       "requires": {
         "is-array-buffer-x": "^1.0.13"
       }
+    },
+    "cached-constructors-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cached-constructors-x/-/cached-constructors-x-1.0.2.tgz",
+      "integrity": "sha512-7lKwmwXweW6E/31RHAJemLtZPfb2xvcABXknFF4b/dNYv4DbSGTgQHckXLQkNw6BB4HKFYW6mJgsNjADAy1ehw=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -579,17 +589,27 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
+    "has-own-property-x": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
+      "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
+      "requires": {
+        "cached-constructors-x": "^1.0.0",
+        "to-object-x": "^1.5.0",
+        "to-property-key-x": "^2.0.2"
+      }
+    },
     "has-symbol-support-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.0.tgz",
-      "integrity": "sha512-F1NtLDtW9NyUrS3faUcI1yVFHCTXyzPb1jfrZBQi5NHxFPlXxZnFLFGzfA2DsdmgCxv2MZ0+bfcgC4EZTmk4SQ=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
     },
     "has-to-string-tag-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.0.tgz",
-      "integrity": "sha512-R3OdOP9j6AH5hS1yXeu9wAS+iKSZQx/CC6aMdN6WiaqPlBoA2S+47MtoMsZgKr2m0eAJ+73WWGX0RaFFE5XWKA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "^1.4.0"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "hawk": {
@@ -673,6 +693,11 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
+    "infinity-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/infinity-x/-/infinity-x-1.0.2.tgz",
+      "integrity": "sha512-2Ioz+exrAwlHxFBaDHQIbvUyjKFt0YjIal34/agfzx738aT1zBQwSU5A8Zgb1IQ2r24BtXrkeZZusxE40MyZaQ=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -689,45 +714,105 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-array-buffer-x": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.3.0.tgz",
-      "integrity": "sha512-whzwpofpDnd+7xMeELyPoBzqYqLtP1mnx66y/3PtsJJ5OzC+z79zr+9ItoEH+BJWm4SaXNR0CIdiUGIMUqXpvw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
+      "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
       "requires": {
-        "has-to-string-tag-x": "^1.4.0",
-        "is-object-like-x": "^1.3.0",
-        "to-string-tag-x": "^1.4.0"
+        "attempt-x": "^1.1.0",
+        "has-to-string-tag-x": "^1.4.1",
+        "is-object-like-x": "^1.5.1",
+        "object-get-own-property-descriptor-x": "^3.2.0",
+        "to-string-tag-x": "^1.4.1"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-falsey-x": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.3.tgz",
+      "integrity": "sha512-RWjusR6LXAhGa0Vus7aD1rwJuJwdJsvG3daAVMDvOAgvGuGm4eilNgoSuXhpv2/2qpLDvioAKTNb3t3XYidCNg==",
+      "requires": {
+        "to-boolean-x": "^1.0.2"
+      }
+    },
+    "is-finite-x": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.4.tgz",
+      "integrity": "sha512-wdSI5zk/Pl21HzGcLWFoFzuDa8gsgcqhwZGAZryL2eU7RKf7+g+q4jL2gGItrBs/YtspkjOrJ4JxXNZqquoAWA==",
+      "requires": {
+        "infinity-x": "^1.0.1",
+        "is-nan-x": "^1.0.2"
       }
     },
     "is-function-x": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.1.0.tgz",
-      "integrity": "sha512-QYIql/y+5SRlQyMCO93R+Gq3mPXkSy49MxsEuSu1DCoEx3UUuw+kbsPn7tGf1oStPchZBAqe20/xfqS1wZGSlQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
+      "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
       "requires": {
-        "has-to-string-tag-x": "^1.4.0",
+        "attempt-x": "^1.1.1",
+        "has-to-string-tag-x": "^1.4.1",
+        "is-falsey-x": "^1.0.1",
         "is-primitive": "^2.0.0",
-        "normalize-space-x": "^1.3.2",
-        "replace-comments-x": "^1.0.1",
-        "to-string-tag-x": "^1.4.0"
+        "normalize-space-x": "^3.0.0",
+        "replace-comments-x": "^2.0.0",
+        "to-boolean-x": "^1.0.1",
+        "to-string-tag-x": "^1.4.2"
+      },
+      "dependencies": {
+        "is-primitive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        }
       }
+    },
+    "is-index-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
+      "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
+      "requires": {
+        "math-clamp-x": "^1.2.0",
+        "max-safe-integer": "^1.0.1",
+        "to-integer-x": "^3.0.0",
+        "to-number-x": "^2.0.0",
+        "to-string-symbols-supported-x": "^1.0.0"
+      }
+    },
+    "is-nan-x": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.3.tgz",
+      "integrity": "sha512-WenNBLVGSZID8shogsB++42vF7gvotCfneXM9KMCAKwNPXa8VfAu/RWwpqvnK7dLOP4Z7uitocb0TZ6rAiOccA=="
     },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
-    "is-object-like-x": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.0.tgz",
-      "integrity": "sha512-8nt2Uf/75/JWi0zL4cSesOkCKW/rcFtNiYi5776ny/LJCchPqheKnx/328MPUaN3uYzkSZKNjo7zbTGMpBfthw==",
+    "is-nil-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.2.tgz",
+      "integrity": "sha512-9aDY7ir7IGb5HlgqL+b38v2YMxf8S7MEHHxjHGzUhijg2crq47RKdxL37bS6dU0VN87wy2IBZP4akgQtIXmyvg==",
       "requires": {
-        "is-function-x": "^3.1.0",
-        "is-primitive": "^2.0.0"
+        "lodash.isnull": "^3.0.0",
+        "validate.io-undefined": "^1.0.3"
+      }
+    },
+    "is-object-like-x": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.7.1.tgz",
+      "integrity": "sha512-89nz+kESAW2Y7udq+PdRX/dZnRN2WP1b19Gdv4OYE1Xjoekn1xf31l0ZPzT40qdPD7I2nveNFm9rxxI0vmnGHA==",
+      "requires": {
+        "is-function-x": "^3.3.0",
+        "is-primitive": "^3.0.0"
       }
     },
     "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.0.tgz",
+      "integrity": "sha512-Qch+MMfMdu7DMY6XElM7LUJKPmkbXdTqNhqyehVflzis2a8Zd9V6U8qZybb32uUSmlO/dNmg3fsA5t0Q9TC0mA=="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -791,14 +876,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -811,11 +888,6 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -880,6 +952,28 @@
       "requires": {
         "pify": "^2.3.0"
       }
+    },
+    "math-clamp-x": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
+      "requires": {
+        "to-number-x": "^2.0.0"
+      }
+    },
+    "math-sign-x": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
+      "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
+      "requires": {
+        "is-nan-x": "^1.0.1",
+        "to-number-x": "^2.0.0"
+      }
+    },
+    "max-safe-integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
+      "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA="
     },
     "mime-db": {
       "version": "1.33.0",
@@ -971,6 +1065,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nan-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.2.tgz",
+      "integrity": "sha512-dndRmy03JQEN+Nh6WjQl7/OstIozeEmrtWe4TE7mEqJ8W8oMD8m2tHjsLPWt//e3hLAeRSbs4pxMyc5pk/nCkQ=="
+    },
     "native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
@@ -991,12 +1090,13 @@
       }
     },
     "normalize-space-x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-1.3.2.tgz",
-      "integrity": "sha512-90FkeM1xmKZ47Kl0JY5PhTQCSfxxxPwqQyv744KRyoHi4Ulp9g9uWoygJR/Rdv1oklABuFnwgej1Y+fb+2pQjA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
+      "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
       "requires": {
-        "trim-x": "^1.0.2",
-        "white-space-x": "^2.0.2"
+        "cached-constructors-x": "^1.0.0",
+        "trim-x": "^3.0.0",
+        "white-space-x": "^3.0.0"
       }
     },
     "oauth-sign": {
@@ -1009,12 +1109,47 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-get-own-property-descriptor-x": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
+      "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
+      "requires": {
+        "attempt-x": "^1.1.0",
+        "has-own-property-x": "^3.1.1",
+        "has-symbol-support-x": "^1.4.1",
+        "is-falsey-x": "^1.0.0",
+        "is-index-x": "^1.0.0",
+        "is-primitive": "^2.0.0",
+        "is-string": "^1.0.4",
+        "property-is-enumerable-x": "^1.1.0",
+        "to-object-x": "^1.4.1",
+        "to-property-key-x": "^2.0.1"
+      },
+      "dependencies": {
+        "is-primitive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        }
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "parse-int-x": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
+      "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
+      "requires": {
+        "cached-constructors-x": "^1.0.0",
+        "nan-x": "^1.0.0",
+        "to-string-x": "^1.4.2",
+        "trim-left-x": "^3.0.0"
       }
     },
     "path-is-absolute": {
@@ -1075,465 +1210,223 @@
       }
     },
     "pouchdb-abstract-mapreduce": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/pouchdb-abstract-mapreduce/-/pouchdb-abstract-mapreduce-6.3.4.tgz",
-      "integrity": "sha512-C8yKWXDUd6sq5FaVBF7Kxa2Ats3+3sqarTPkTSdgQCiGRouy4RL++rpDVforCKQc/kmG7MrnZ0XjL85m5/IbUQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-abstract-mapreduce/-/pouchdb-abstract-mapreduce-6.4.3.tgz",
+      "integrity": "sha512-omSNRtSf5S/O6SdIy3RV5ODdftL7x0txoBKo2BBr72Ji1r3460ftRfKzurRnHwTYTPzxAZYqm2IkRExSqQRfNQ==",
       "requires": {
-        "pouchdb-binary-utils": "6.3.4",
-        "pouchdb-collate": "6.3.4",
-        "pouchdb-collections": "6.3.4",
-        "pouchdb-mapreduce-utils": "6.3.4",
-        "pouchdb-md5": "6.3.4",
-        "pouchdb-promise": "6.3.4",
-        "pouchdb-utils": "6.3.4"
+        "pouchdb-binary-utils": "6.4.3",
+        "pouchdb-collate": "6.4.3",
+        "pouchdb-collections": "6.4.3",
+        "pouchdb-mapreduce-utils": "6.4.3",
+        "pouchdb-md5": "6.4.3",
+        "pouchdb-promise": "6.4.3",
+        "pouchdb-utils": "6.4.3"
+      }
+    },
+    "pouchdb-adapter-http": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-http/-/pouchdb-adapter-http-6.4.3.tgz",
+      "integrity": "sha512-4z3nePxJVH/O1tx0v8h2XXtkT0YdN34+QjXIz7ujBK8ioobb7Dmi7YqFKr6Yv8g9tKslzl4nxrOQk3HBV/dbhA==",
+      "requires": {
+        "argsarray": "0.0.1",
+        "pouchdb-ajax": "6.4.3",
+        "pouchdb-binary-utils": "6.4.3",
+        "pouchdb-errors": "6.4.3",
+        "pouchdb-promise": "6.4.3",
+        "pouchdb-utils": "6.4.3"
+      }
+    },
+    "pouchdb-ajax": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-ajax/-/pouchdb-ajax-6.4.3.tgz",
+      "integrity": "sha512-3ySZrbEYjbosXShWFLk3xW8prrrUOG8z5aXKy+6lK/nokqdpqGj9NQX/gffy15VcDswbJyQtKpVQRevQlLuAGA==",
+      "requires": {
+        "buffer-from": "0.1.1",
+        "pouchdb-binary-utils": "6.4.3",
+        "pouchdb-errors": "6.4.3",
+        "pouchdb-promise": "6.4.3",
+        "pouchdb-utils": "6.4.3",
+        "request": "2.83.0"
       },
       "dependencies": {
-        "pouchdb-binary-utils": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-6.3.4.tgz",
-          "integrity": "sha512-sjQwbtbg4yb6FOF1LJbdXlOVb2q7VImxxX2+8qsyrRyOzk9AdahTx/Ui4CVBPJO3w5M9HA52X0ou8eCsjtjEcg==",
+        "request": {
+          "version": "2.83.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "requires": {
-            "buffer-from": "0.1.1"
-          }
-        },
-        "pouchdb-collate": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-6.3.4.tgz",
-          "integrity": "sha512-Tk9x+EAXLOvT4uk+63RYsn1K335u0PnBGSQUmynrkYqsVAb0etmuoBzKJinKD8ZprGhuAiFEyu0mZG71+atCJg=="
-        },
-        "pouchdb-collections": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.3.4.tgz",
-          "integrity": "sha512-F+o2SGRO5FZwoURVVcuj1hd94YN9DVr8sD/kg2pXhf2m/nJ2GfMiR4l88h9bh2VYb8BDNU3OQj6gXebzfxSwjA=="
-        },
-        "pouchdb-errors": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.3.4.tgz",
-          "integrity": "sha512-w96XRbS6hSFmCt+YmoUA2s6TsP8aUTteZ9BZ/Jjkcv5EdSlHwTKpmaBG5WG3givjCSmfP7+ZMCSDEop2PPcdqg==",
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "pouchdb-promise": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.3.4.tgz",
-          "integrity": "sha512-9kgpKXWFuFYJmhP7pjZvPhK9Lof8ipFVIoaZrFQN8HMep9/IdmhyXMUlISHkaNt3l0yWzW8bWYPg3OMocImvHA==",
-          "requires": {
-            "lie": "3.1.1"
-          }
-        },
-        "pouchdb-utils": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.3.4.tgz",
-          "integrity": "sha512-63mnIL7MX3ciyW1zWRl8OOUHZqRjeB1bC9kbFE+56F3U9T5OHMgkDcTukHRKXSfSnHPXoS+QujU3ups0SYsKIw==",
-          "requires": {
-            "argsarray": "0.0.1",
-            "clone-buffer": "1.0.0",
-            "immediate": "3.0.6",
-            "inherits": "2.0.3",
-            "pouchdb-collections": "6.3.4",
-            "pouchdb-errors": "6.3.4",
-            "pouchdb-promise": "6.3.4",
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
             "uuid": "^3.1.0"
           }
         }
       }
     },
-    "pouchdb-adapter-http": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-adapter-http/-/pouchdb-adapter-http-6.2.0.tgz",
-      "integrity": "sha1-Y8gW0mCJBL37IAtqPVpR2LHpLrQ=",
-      "requires": {
-        "argsarray": "0.0.1",
-        "pouchdb-ajax": "6.2.0",
-        "pouchdb-binary-utils": "6.2.0",
-        "pouchdb-errors": "6.2.0",
-        "pouchdb-promise": "6.2.0",
-        "pouchdb-utils": "6.2.0"
-      }
-    },
-    "pouchdb-ajax": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-ajax/-/pouchdb-ajax-6.2.0.tgz",
-      "integrity": "sha1-YqEz+Llc6KqFa4Fp1NbmAUJjHmM=",
-      "requires": {
-        "buffer-from": "0.1.1",
-        "pouchdb-binary-utils": "6.2.0",
-        "pouchdb-errors": "6.2.0",
-        "pouchdb-promise": "6.2.0",
-        "pouchdb-utils": "6.2.0",
-        "request": "2.80.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
-        },
-        "request": {
-          "version": "2.80.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.80.0.tgz",
-          "integrity": "sha1-jMFi1215OBze/dNQXXa4C2BYm9A=",
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.0",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-        }
-      }
-    },
     "pouchdb-binary-utils": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-6.2.0.tgz",
-      "integrity": "sha1-3EFUwBuS+5rYf99pU5SpG12UKb8=",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-6.4.3.tgz",
+      "integrity": "sha512-eRKH/1eiZwrqNdAR3CL1XIIkq04I9hHIABHwIRboz1LjBSchKmaf4ZDngiWGDvRYT9Gl/MogGDGOk1WRMoV4wg==",
       "requires": {
         "buffer-from": "0.1.1"
       }
     },
     "pouchdb-changes-filter": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-changes-filter/-/pouchdb-changes-filter-6.2.0.tgz",
-      "integrity": "sha1-YmSVVM7yyefoRsRS6w01zggRpeg=",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-changes-filter/-/pouchdb-changes-filter-6.4.3.tgz",
+      "integrity": "sha512-u90MocOmysuwXmKsz8dgDKGrbzYY/M2POghqGqy6PMUI3vzq4YEwGB/gWym06alI1pQzMKjpZ20KTzwRDC/6zQ==",
       "requires": {
-        "pouchdb-errors": "6.2.0",
-        "pouchdb-selector-core": "6.2.0",
-        "pouchdb-utils": "6.2.0"
+        "pouchdb-errors": "6.4.3",
+        "pouchdb-selector-core": "6.4.3",
+        "pouchdb-utils": "6.4.3"
       }
     },
     "pouchdb-collate": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-6.2.0.tgz",
-      "integrity": "sha1-nuXleN4ARYHBSHVPfezcC3BJX/w="
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-6.4.3.tgz",
+      "integrity": "sha512-iwKAdc8vjLx8AzxBFnfV24Hp4FkbADTUcuQl/2IUOaF8JzZ/wVYa0DgBd+uErk2rj5yf1HxFp+5/9EgHV4PxAw=="
     },
     "pouchdb-collections": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.2.0.tgz",
-      "integrity": "sha1-9TJgGHDL0ym6DGAFvN0wESaCW+I="
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.4.3.tgz",
+      "integrity": "sha512-uWb9+hvjiijeyrCeEz/FUND1oj0AQK/f166egBOTofNlAwQLNrJUTn+uJ34b3NODAmKhg7+ZeDVvnl9D2pijuQ=="
     },
     "pouchdb-core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-core/-/pouchdb-core-6.2.0.tgz",
-      "integrity": "sha1-8xDPUXlMtJNj+zmKFP9mg4z29RE=",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-core/-/pouchdb-core-6.4.3.tgz",
+      "integrity": "sha512-ZYYgdHdhDQBnnzuKsjhbi71SZO+/wRI1gk8b0u50LkXnDja0muhHX+fEAy3oHkybHOaal3u369XhPIV7TefWRQ==",
       "requires": {
         "argsarray": "0.0.1",
         "inherits": "2.0.3",
-        "pouchdb-changes-filter": "6.2.0",
-        "pouchdb-collections": "6.2.0",
-        "pouchdb-debug": "6.2.0",
-        "pouchdb-errors": "6.2.0",
-        "pouchdb-merge": "6.2.0",
-        "pouchdb-promise": "6.2.0",
-        "pouchdb-utils": "6.2.0"
+        "pouchdb-changes-filter": "6.4.3",
+        "pouchdb-collections": "6.4.3",
+        "pouchdb-debug": "6.4.3",
+        "pouchdb-errors": "6.4.3",
+        "pouchdb-merge": "6.4.3",
+        "pouchdb-promise": "6.4.3",
+        "pouchdb-utils": "6.4.3"
       }
     },
     "pouchdb-debug": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-debug/-/pouchdb-debug-6.2.0.tgz",
-      "integrity": "sha1-1WF6X8uziB/stF4iVQ3udQqN5cM=",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-debug/-/pouchdb-debug-6.4.3.tgz",
+      "integrity": "sha512-uU3JrSBJSREAN9mtXaaQTWgTukPx5ik6TyFx/0BrxonsJ8WWxqRWiuQKtCVOfTKP1XRUY0Ed9uKlS2iw1MmZtA==",
       "requires": {
-        "debug": "2.6.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
-          "integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-        }
+        "debug": "3.1.0"
       }
     },
     "pouchdb-errors": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.2.0.tgz",
-      "integrity": "sha1-XMvvryuS6RjV2QtaW3eTdkZLWQc=",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.4.3.tgz",
+      "integrity": "sha512-EU83ZZJjorwGL9DQZ9HAILY8D+ulX2RYVMtsCfIuzaIJEUrHh/dhSIy5854n42NBOUWug3gFDyO58w5k+64HTQ==",
       "requires": {
         "inherits": "2.0.3"
       }
     },
     "pouchdb-mapreduce": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce/-/pouchdb-mapreduce-6.3.4.tgz",
-      "integrity": "sha512-zL4JTT44ra+on1caeUajhshYK5WhgbhbJNtYwYjlqJZOALEiS/BuGe89Ss2w3hZLVFRCavdM4cF9WK/KRPmQ0g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce/-/pouchdb-mapreduce-6.4.3.tgz",
+      "integrity": "sha512-hffB4/ecq5HwLPztRZrTDf/BgzwjvRDJQjTcVJ4h/Jd8g7jGkkPUUcXP4ky7lOf2DBG9hEDFo1/dE1IlMJmqSg==",
       "requires": {
-        "pouchdb-abstract-mapreduce": "6.3.4",
-        "pouchdb-mapreduce-utils": "6.3.4",
-        "pouchdb-utils": "6.3.4"
-      },
-      "dependencies": {
-        "pouchdb-collections": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.3.4.tgz",
-          "integrity": "sha512-F+o2SGRO5FZwoURVVcuj1hd94YN9DVr8sD/kg2pXhf2m/nJ2GfMiR4l88h9bh2VYb8BDNU3OQj6gXebzfxSwjA=="
-        },
-        "pouchdb-errors": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.3.4.tgz",
-          "integrity": "sha512-w96XRbS6hSFmCt+YmoUA2s6TsP8aUTteZ9BZ/Jjkcv5EdSlHwTKpmaBG5WG3givjCSmfP7+ZMCSDEop2PPcdqg==",
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "pouchdb-promise": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.3.4.tgz",
-          "integrity": "sha512-9kgpKXWFuFYJmhP7pjZvPhK9Lof8ipFVIoaZrFQN8HMep9/IdmhyXMUlISHkaNt3l0yWzW8bWYPg3OMocImvHA==",
-          "requires": {
-            "lie": "3.1.1"
-          }
-        },
-        "pouchdb-utils": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.3.4.tgz",
-          "integrity": "sha512-63mnIL7MX3ciyW1zWRl8OOUHZqRjeB1bC9kbFE+56F3U9T5OHMgkDcTukHRKXSfSnHPXoS+QujU3ups0SYsKIw==",
-          "requires": {
-            "argsarray": "0.0.1",
-            "clone-buffer": "1.0.0",
-            "immediate": "3.0.6",
-            "inherits": "2.0.3",
-            "pouchdb-collections": "6.3.4",
-            "pouchdb-errors": "6.3.4",
-            "pouchdb-promise": "6.3.4",
-            "uuid": "^3.1.0"
-          }
-        }
+        "pouchdb-abstract-mapreduce": "6.4.3",
+        "pouchdb-mapreduce-utils": "6.4.3",
+        "pouchdb-utils": "6.4.3"
       }
     },
     "pouchdb-mapreduce-utils": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce-utils/-/pouchdb-mapreduce-utils-6.3.4.tgz",
-      "integrity": "sha512-ZgEGqWUFGMTKAOq47L1SP4uV1LSsxivQsRE5ffXxbjc9GrS0lO/t97oOhqQHYK06KX0jh+5t2OHK0yGAO6Y7bg==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce-utils/-/pouchdb-mapreduce-utils-6.4.3.tgz",
+      "integrity": "sha512-gbxX6h+nOKPDv2eYZznUthHiZ1Ml1xViE8DalEy6+fPzCba6CZ6dTKGZoFrBg4oLF3Wc+cUNX9Uk8cezVMGOhA==",
       "requires": {
         "argsarray": "0.0.1",
         "inherits": "2.0.3",
-        "pouchdb-collections": "6.3.4",
-        "pouchdb-utils": "6.3.4"
-      },
-      "dependencies": {
-        "pouchdb-collections": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.3.4.tgz",
-          "integrity": "sha512-F+o2SGRO5FZwoURVVcuj1hd94YN9DVr8sD/kg2pXhf2m/nJ2GfMiR4l88h9bh2VYb8BDNU3OQj6gXebzfxSwjA=="
-        },
-        "pouchdb-errors": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.3.4.tgz",
-          "integrity": "sha512-w96XRbS6hSFmCt+YmoUA2s6TsP8aUTteZ9BZ/Jjkcv5EdSlHwTKpmaBG5WG3givjCSmfP7+ZMCSDEop2PPcdqg==",
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "pouchdb-promise": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.3.4.tgz",
-          "integrity": "sha512-9kgpKXWFuFYJmhP7pjZvPhK9Lof8ipFVIoaZrFQN8HMep9/IdmhyXMUlISHkaNt3l0yWzW8bWYPg3OMocImvHA==",
-          "requires": {
-            "lie": "3.1.1"
-          }
-        },
-        "pouchdb-utils": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.3.4.tgz",
-          "integrity": "sha512-63mnIL7MX3ciyW1zWRl8OOUHZqRjeB1bC9kbFE+56F3U9T5OHMgkDcTukHRKXSfSnHPXoS+QujU3ups0SYsKIw==",
-          "requires": {
-            "argsarray": "0.0.1",
-            "clone-buffer": "1.0.0",
-            "immediate": "3.0.6",
-            "inherits": "2.0.3",
-            "pouchdb-collections": "6.3.4",
-            "pouchdb-errors": "6.3.4",
-            "pouchdb-promise": "6.3.4",
-            "uuid": "^3.1.0"
-          }
-        }
+        "pouchdb-collections": "6.4.3",
+        "pouchdb-utils": "6.4.3"
       }
     },
     "pouchdb-md5": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-6.3.4.tgz",
-      "integrity": "sha512-rd162ZigLEJZ6OotY6EJsM/hbWPTE5Dhr4WHTOJekv59n4Sp0/3Fq/MB5XFFfM6lZFrvuvd9Q6yzHwk4edemLw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-6.4.3.tgz",
+      "integrity": "sha512-EnToEO+JLJA5bHDYWs42B8hU9Q1TckVozQjTSXL/pDXKXLATuVEKHNq8F/4lrpxblpngx4Zt8z2Luwu0etLSqw==",
       "requires": {
-        "pouchdb-binary-utils": "6.3.4",
+        "pouchdb-binary-utils": "6.4.3",
         "spark-md5": "3.0.0"
-      },
-      "dependencies": {
-        "pouchdb-binary-utils": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-6.3.4.tgz",
-          "integrity": "sha512-sjQwbtbg4yb6FOF1LJbdXlOVb2q7VImxxX2+8qsyrRyOzk9AdahTx/Ui4CVBPJO3w5M9HA52X0ou8eCsjtjEcg==",
-          "requires": {
-            "buffer-from": "0.1.1"
-          }
-        }
       }
     },
     "pouchdb-merge": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-merge/-/pouchdb-merge-6.2.0.tgz",
-      "integrity": "sha1-ZcptlK7W+bO1H+2TGNM6MCqZ7i8="
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-merge/-/pouchdb-merge-6.4.3.tgz",
+      "integrity": "sha512-UuSpex/V1kNr1aXcmg+TQlOdjzMWc08AX/Ja6jrPq9J42M97UFF+7Ijx3JllxDK0j6QJZrvhpvjFzsRhFC4+zw=="
     },
     "pouchdb-promise": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.2.0.tgz",
-      "integrity": "sha1-Hk/OwKoGeN9YPmp7S5lroBCmCP4=",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.4.3.tgz",
+      "integrity": "sha512-ruJaSFXwzsxRHQfwNHjQfsj58LBOY1RzGzde4PM5CWINZwFjCQAhZwfMrch2o/0oZT6d+Xtt0HTWhq35p3b0qw==",
       "requires": {
         "lie": "3.1.1"
       }
     },
     "pouchdb-selector-core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-selector-core/-/pouchdb-selector-core-6.2.0.tgz",
-      "integrity": "sha1-q3U8Fxgrw5TmprHeJ1MxFh+F4yU=",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-selector-core/-/pouchdb-selector-core-6.4.3.tgz",
+      "integrity": "sha512-Wx+gPE2cC5AsuNQrelaWQV3J3U75MkcxIYsQeIBHaEth/WOxjQ3MTWGwKdyaNdVX8Opp8Sj7VFRIZpI+HubQ4g==",
       "requires": {
-        "pouchdb-collate": "6.2.0",
-        "pouchdb-utils": "6.2.0"
+        "pouchdb-collate": "6.4.3",
+        "pouchdb-utils": "6.4.3"
       }
     },
     "pouchdb-utils": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.2.0.tgz",
-      "integrity": "sha1-zY1CB6NOR4tJryAf8MUepzMkQGE=",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.4.3.tgz",
+      "integrity": "sha512-22QXh743YXl/afheeumrUKsO/0Q4Q8bvoboFp/1quXq//BDJa9nv55WUZX0l05t3VPW+nD/pse2FzU9cs3nEag==",
       "requires": {
         "argsarray": "0.0.1",
         "clone-buffer": "1.0.0",
         "immediate": "3.0.6",
         "inherits": "2.0.3",
-        "pouchdb-collections": "6.2.0",
-        "pouchdb-errors": "6.2.0",
-        "pouchdb-promise": "6.2.0"
+        "pouchdb-collections": "6.4.3",
+        "pouchdb-errors": "6.4.3",
+        "pouchdb-promise": "6.4.3",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+        }
       }
     },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "property-is-enumerable-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
+      "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
+      "requires": {
+        "to-object-x": "^1.4.1",
+        "to-property-key-x": "^2.0.1"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -1560,11 +1453,12 @@
       }
     },
     "replace-comments-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-1.0.1.tgz",
-      "integrity": "sha512-FZLlrcoYb3Cb8bzPxiUTaMR7lm7ZTuUTovb6bHL+aMf41HnGgyRL+oABQ6KKoZo1JBt2UXZs5t2MI06ei2KupA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
+      "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
       "requires": {
-        "is-string": "^1.0.4"
+        "require-coercible-to-string-x": "^1.0.0",
+        "to-string-x": "^1.4.2"
       }
     },
     "request": {
@@ -1619,6 +1513,23 @@
         "request-promise-core": "1.1.1",
         "stealthy-require": "^1.1.0",
         "tough-cookie": ">=2.3.3"
+      }
+    },
+    "require-coercible-to-string-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.2.tgz",
+      "integrity": "sha512-GZ3BSCL0n/zhho8ITganW9FGPh0Kxhq71nCjck8Qau/30Wf4Po8a3XpQdzEMFiXCwZ/0m0E3lKSdSG8gkcIofQ==",
+      "requires": {
+        "require-object-coercible-x": "^1.4.3",
+        "to-string-x": "^1.4.5"
+      }
+    },
+    "require-object-coercible-x": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.3.tgz",
+      "integrity": "sha512-5wEaS+NIiU5HLJQTqBQ+6XHtX7yplUS374j/H/nRDlc7rMWfENqp026jnUHWAOCZ+ekixkXuFHEnTF28oqqVLA==",
+      "requires": {
+        "is-nil-x": "^1.4.2"
       }
     },
     "safe-buffer": {
@@ -1760,20 +1671,100 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "to-boolean-x": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.3.tgz",
+      "integrity": "sha512-kQiMyJUgFprL8J+0CfgJuaSFKJMs3EvFe27/6aj/hVzVZT0HY4aA1QjPldLNxzBmjhLcapp7CctYHuD8QqtS3g=="
+    },
+    "to-integer-x": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
+      "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
+      "requires": {
+        "is-finite-x": "^3.0.2",
+        "is-nan-x": "^1.0.1",
+        "math-sign-x": "^3.0.0",
+        "to-number-x": "^2.0.0"
+      }
+    },
+    "to-number-x": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
+      "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
+      "requires": {
+        "cached-constructors-x": "^1.0.0",
+        "nan-x": "^1.0.0",
+        "parse-int-x": "^2.0.0",
+        "to-primitive-x": "^1.1.0",
+        "trim-x": "^3.0.0"
+      }
+    },
+    "to-object-x": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
+      "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
+      "requires": {
+        "cached-constructors-x": "^1.0.0",
+        "require-object-coercible-x": "^1.4.1"
+      }
+    },
+    "to-primitive-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
+      "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1",
+        "is-date-object": "^1.0.1",
+        "is-function-x": "^3.2.0",
+        "is-nil-x": "^1.4.1",
+        "is-primitive": "^2.0.0",
+        "is-symbol": "^1.0.1",
+        "require-object-coercible-x": "^1.4.1",
+        "validate.io-undefined": "^1.0.3"
+      },
+      "dependencies": {
+        "is-primitive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        }
+      }
+    },
+    "to-property-key-x": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
+      "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1",
+        "to-primitive-x": "^1.1.0",
+        "to-string-x": "^1.4.2"
+      }
+    },
+    "to-string-symbols-supported-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.2.tgz",
+      "integrity": "sha512-3MRqhIhSNVDsVAk4M6WNcuBZrAQe54W13xrXX6RzxXS+pA4nj6DQ96RegQS5z9BSNyYbFsBsPvMVDIpP+a/5RA==",
+      "requires": {
+        "cached-constructors-x": "^1.0.2",
+        "has-symbol-support-x": "^1.4.2",
+        "is-symbol": "^1.0.1"
+      }
+    },
     "to-string-tag-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.0.tgz",
-      "integrity": "sha512-+hKRhsBP35H2Poucdg/lnHnV3OBwx9Ynz865ZBtdCY5kcgFzOVpGq2zjKHSvOaQDUk/FITmsDHRtCLYBi67vVA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.3.tgz",
+      "integrity": "sha512-5+0EZ6dOVt/XArXmkooxPzWxmOR081HM/uXitUow7h11WYg5pPo15uYqDWuqO7ZY+O3Atn/dG26wcJCK+mFevg==",
       "requires": {
         "lodash.isnull": "^3.0.0",
         "validate.io-undefined": "^1.0.3"
       }
     },
     "to-string-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.0.tgz",
-      "integrity": "sha512-Wc3+16c087b3Oj8ycNLrdJmQPkGGMdtPdeDwsWhNwtTGnGClNdcqUuoZSq0d9br6qh9GDPtlCUjyhz8eIwPmZQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.5.tgz",
+      "integrity": "sha512-5xzlZDyDa9BUWNjNzZzHgKQ95PnV7qjvEhbqpFaj1ixaHgfJXOFaa3xdMJ+WLYd4hhaMJaxt8Pt5uKaWXfruXA==",
       "requires": {
+        "cached-constructors-x": "^1.0.0",
         "is-symbol": "^1.0.1"
       }
     },
@@ -1786,30 +1777,32 @@
       }
     },
     "trim-left-x": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-1.3.3.tgz",
-      "integrity": "sha512-+BR0IT+4pQvoQemCY0j6D6aFs2W/9mpYuXMtPtTWjwd2Juq7JFlprBvLBJF6FdlEOkKneG4Zwc7zcf4Zdj7j1g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
+      "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
       "requires": {
-        "to-string-x": "^1.4.0",
-        "white-space-x": "^2.0.2"
+        "cached-constructors-x": "^1.0.0",
+        "require-coercible-to-string-x": "^1.0.0",
+        "white-space-x": "^3.0.0"
       }
     },
     "trim-right-x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-1.3.2.tgz",
-      "integrity": "sha512-BFpADj8aAgQb8+KSOEIC9KNZXCqybLA94F0lAnyXxF9D3P0IBzQ3/qPPGw3KkDV0uy38z75mHeGPq47Uucwvpw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
+      "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
       "requires": {
-        "to-string-x": "^1.4.0",
-        "white-space-x": "^2.0.2"
+        "cached-constructors-x": "^1.0.0",
+        "require-coercible-to-string-x": "^1.0.0",
+        "white-space-x": "^3.0.0"
       }
     },
     "trim-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-1.0.2.tgz",
-      "integrity": "sha512-jH5BwdQ+/sFqrKhJyJiX3wck5UVzZZbVOm7468zijazVddT9y5/gf+XlwHo9bOYhLPLsUbnsSivCT2G3dXcQJg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
+      "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
       "requires": {
-        "trim-left-x": "^1.3.3",
-        "trim-right-x": "^1.3.2"
+        "trim-left-x": "^3.0.0",
+        "trim-right-x": "^3.0.0"
       }
     },
     "tunnel-agent": {
@@ -1872,9 +1865,9 @@
       }
     },
     "white-space-x": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.2.tgz",
-      "integrity": "sha512-fFV+/CTimN5y1ivUbnnH1yL/D8WiXqK9IixeLlxXWMttTJWY6g40v7o+i0Q6wFH0eQ/IPo8fBH2CaquIwEDkxw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.1.tgz",
+      "integrity": "sha512-BwMFXQNPna/4RsNPOgldVYn+FkEv+lc3wUiFzuaW6Z2DH/oSk1UrRD6SBqDgWQO4JU+aBq3PVuPD9Vz0j7mh0w=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1622,9 +1622,9 @@
       }
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-dirs": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "fs-extra": "^3.0.1",
     "lockfile": "^1.0.4",
     "minimist": "^1.2.0",
-    "pouchdb-adapter-http": "^6.2.0",
-    "pouchdb-core": "^6.2.0",
-    "pouchdb-mapreduce": "^6.2.0",
+    "pouchdb-adapter-http": "^6.4.3",
+    "pouchdb-core": "^6.4.3",
+    "pouchdb-mapreduce": "^6.4.3",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
     "signal-exit": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "signal-exit": "^3.0.2"
   },
   "devDependencies": {
+    "chai-as-promised": "^7.1.1",
     "chai": "^4.1.2",
     "jshint": "^2.9.4",
     "mocha": "^5.0.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,18 @@
+module.exports = {
+  LEGACY_0_8_UPGRADE_DOC: '_design/medic:staged',
+  HORTI_UPGRADE_DOC: 'horti-upgrade',
+  ACTIONS: {
+    // A complete installation from start to finish. End result is a deleted
+    // HORTI_UPGRADE_DOC and the system running on the new version.
+    INSTALL: 'install',
+    // A partial installation that aims to complete as much work as possible
+    // without actually deploying to the new version. End result is the
+    // HORTI_UPGRADE_DOC being marked as `staging_complete`, ready to be
+    // COMPLETEd.
+    STAGE: 'stage',
+    // Completes a STAGEd installation. The expectation is that an installation
+    // has already been STAGEd and is ready to be deployed. This expectation is
+    // maintined in the api that writes the HORTI_UPGRADE_DOC.
+    COMPLETE: 'complete'
+  }
+};

--- a/src/install/deploySteps.js
+++ b/src/install/deploySteps.js
@@ -187,9 +187,14 @@ module.exports = (apps, mode, deployDoc) => {
             .then(() => unzipChangedApps(ddoc, changedApps))
             .then(() => info('Changed apps unzipped.'))
 
-            .then(() => info('Stopping all apps…', apps.APPS))
-            .then(() => apps.stop())
-            .then(() => info('All apps stopped.'));
+            .then(() => {
+              if (mode.daemon) {
+                return Promise.resolve()
+                  .then(() => info('Stopping all apps…', apps.APPS))
+                  .then(() => apps.stop())
+                  .then(() => info('All apps stopped.'));
+              }
+            });
         } else {
           debug('No apps to deploy');
         }
@@ -206,8 +211,11 @@ module.exports = (apps, mode, deployDoc) => {
         }
       })
 
-      .then(() => (appsToDeploy || firstRun) && startApps())
-      .then(() => true);
+      .then(() => {
+        if (mode.daemon && (appsToDeploy || firstRun)) {
+          return startApps();
+        }
+      });
   };
 
   const moduleWithContext = {

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -246,7 +246,7 @@ const deploySteps = (apps, mode, deployDoc, firstRun, ddoc) => {
   };
 
   const stage = stager(deployDoc);
-  return stage('Initiating deployment')
+  return stage('horti.stage.initDeploy', 'Initiating deployment')
     .then(getApplicationDdoc)
     .then(ddoc => {
       return stage('horti.stage.deploying', 'Deploying new installation')

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -1,4 +1,8 @@
-const should = require('chai').should();
+const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised);
+
+const should = chai.should();
 
 const sinon = require('sinon').sandbox.create();
 const DB = require('../src/dbs');
@@ -15,10 +19,29 @@ describe('Bootstrap', () => {
   it('creates an upgrade doc with a known version', () => {
     DB.app.get.rejects({status: 404});
     DB.app.put.resolves({rev: '1-some-rev'});
-    return bootstrap.bootstrap('1.0.0')
+    return bootstrap.install('1.0.0')
       .then(deployDoc => {
         DB.app.put.callCount.should.equal(1);
         DB.app.put.args[0][0]._id.should.equal('horti-upgrade');
+        DB.app.put.args[0][0].action.should.equal('install');
+        DB.app.put.args[0][0].build_info.should.deep.equal({
+          namespace: 'medic',
+          application: 'medic',
+          version: '1.0.0'
+        });
+
+        deployDoc.should.deep.equal(DB.app.put.args[0][0]);
+      });
+  });
+
+  it('creates an upgrade doc with a known version set to stage', () => {
+    DB.app.get.rejects({status: 404});
+    DB.app.put.resolves({rev: '1-some-rev'});
+    return bootstrap.stage('1.0.0')
+      .then(deployDoc => {
+        DB.app.put.callCount.should.equal(1);
+        DB.app.put.args[0][0]._id.should.equal('horti-upgrade');
+        DB.app.put.args[0][0].action.should.equal('stage');
         DB.app.put.args[0][0].build_info.should.deep.equal({
           namespace: 'medic',
           application: 'medic',
@@ -36,7 +59,7 @@ describe('Bootstrap', () => {
       id: 'medic:medic:1.0.0'
     }]});
 
-    return bootstrap.bootstrap('@release')
+    return bootstrap.install('@release')
       .then(() => {
         DB.builds.query.callCount.should.equal(1);
         DB.builds.query.args[0][0].should.equal('builds/releases');
@@ -56,7 +79,7 @@ describe('Bootstrap', () => {
     DB.app.get.resolves({_id: 'existing-doc', _rev: 'some-rev', extra: 'data'});
     DB.app.put.resolves({rev: '1-some-rev'});
 
-    return bootstrap.bootstrap('1.0.0')
+    return bootstrap.install('1.0.0')
       .then(() => {
         DB.app.get.callCount.should.equal(1);
         DB.app.put.callCount.should.equal(1);
@@ -67,6 +90,30 @@ describe('Bootstrap', () => {
           application: 'medic',
           version: '1.0.0'
         });
+      });
+  });
+
+  it('Errors if you try to complete when there is no existing deploy doc', () => {
+    DB.app.get.rejects({status: 404});
+    return bootstrap.complete()
+      .should.be.rejectedWith(/no installation to complete/);
+  });
+
+  it('Errors if you try to complete when the existing deploy is not ready', () => {
+    DB.app.get.resolves({_id: 'horti-upgrade', _rev: 'some-rev'});
+
+    return bootstrap.complete()
+      .should.be.rejectedWith(/not ready to complete/);
+  });
+
+  it('Transitions a staged deploy into a real one', () => {
+    DB.app.get.resolves({_id: 'horti-upgrade', _rev: 'some-rev', staging_complete: true});
+    DB.app.put.resolves({rev: '1-some-rev'});
+
+    return bootstrap.complete()
+      .then(() => {
+        DB.app.put.callCount.should.equal(1);
+        DB.app.put.args[0][0].action.should.equal('complete');
       });
   });
 });


### PR DESCRIPTION
You can now install, stage and complete a staged install from the
command line. Running horti daemonless now actually makes sense, with it
performing the given action and then stopping.

This change allows for easier migrations from 2.x to 3.0 because once
you've replicated data over to the new instance you can run horti with:

  horti --stage=3.0.0 --no-daemon

To pre-prepare the instance as much as possible for the deploy. Once
you're ready to make the switch you can run:

  horti --complete-install --no-daemon

And once that is done run horti as you would normally do via
supervisor.d (or just run horti --complete-install and have the daemon
run from there)

medic/medic-webapp#3257