### PR TITLE
Groups _active_tasks output by ddoc and calculates overall progress

### DIFF
--- a/tests/install.js
+++ b/tests/install.js
@@ -202,50 +202,50 @@ describe('Installation flow', () => {
     it('Groups active tasks by ddoc and calculates an overall progress', () => {
       const indexers = [
         [
-          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 3, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard/2/medic', design_document: '_design/:staged:medic', progress: 4, pid: 's-m-2', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 2, pid: 's-m-3', type: 'indexer' },
+          { database: 'shard1', design_document: ':staged:medic', progress: 3, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard2', design_document: ':staged:medic', progress: 4, pid: 's-m-2', type: 'indexer' },
+          { database: 'shard3', design_document: ':staged:medic', progress: 2, pid: 's-m-3', type: 'indexer' },
 
-          { database: 'shard/1/medic', design_document: '_design/:staged:medic-client', progress: 7, pid: 's-mc-1', type: 'indexer' },
-          { database: 'shard/2/medic', design_document: '_design/:staged:medic-client', progress: 10, pid: 's-mc-2', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/:staged:medic-client', progress: 5, pid: 's-mc-3', type: 'indexer' },
+          { database: 'shard1', design_document: ':staged:medic-client', progress: 7, pid: 's-mc-1', type: 'indexer' },
+          { database: 'shard2', design_document: ':staged:medic-client', progress: 10, pid: 's-mc-2', type: 'indexer' },
+          { database: 'shard3', design_document: ':staged:medic-client', progress: 5, pid: 's-mc-3', type: 'indexer' },
 
-          { database: 'shard/1/medic', design_document: '_design/medic', progress: 77, pid: 'm-1', type: 'indexer' },
-          { database: 'shard/2/medic', design_document: '_design/medic', progress: 99, pid: 'm-2', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/medic', progress: 52, pid: 'm-3', type: 'indexer' },
+          { database: 'shard1', design_document: 'medic', progress: 77, pid: 'm-1', type: 'indexer' },
+          { database: 'shard2', design_document: 'medic', progress: 99, pid: 'm-2', type: 'indexer' },
+          { database: 'shard3', design_document: 'medic', progress: 52, pid: 'm-3', type: 'indexer' },
         ],
         [
-          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 22, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard/2/medic', design_document: '_design/:staged:medic', progress: 29, pid: 's-m-2', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 18, pid: 's-m-3', type: 'indexer'},
+          { database: 'shard1', design_document: ':staged:medic', progress: 22, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard2', design_document: ':staged:medic', progress: 29, pid: 's-m-2', type: 'indexer' },
+          { database: 'shard3', design_document: ':staged:medic', progress: 18, pid: 's-m-3', type: 'indexer'},
 
-          { database: 'shard/1/medic', design_document: '_design/:staged:medic-client', progress: 36, pid: 's-mc-1', type: 'indexer' },
-          { database: 'shard/2/medic', design_document: '_design/:staged:medic-client', progress: 41, pid: 's-mc-2', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/:staged:medic-client', progress: 55, pid: 's-mc-3', type: 'indexer' },
+          { database: 'shard1', design_document: ':staged:medic-client', progress: 36, pid: 's-mc-1', type: 'indexer' },
+          { database: 'shard2', design_document: ':staged:medic-client', progress: 41, pid: 's-mc-2', type: 'indexer' },
+          { database: 'shard3', design_document: ':staged:medic-client', progress: 55, pid: 's-mc-3', type: 'indexer' },
 
-          { database: 'shard/1/medic', design_document: '_design/medic', progress: 87, pid: 'm-1', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/medic', progress: 95, pid: 'm-3', type: 'indexer' },
+          { database: 'shard1', design_document: 'medic', progress: 87, pid: 'm-1', type: 'indexer' },
+          { database: 'shard3', design_document: 'medic', progress: 95, pid: 'm-3', type: 'indexer' },
         ],
         [
-          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 49, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard/2/medic', design_document: '_design/:staged:medic', progress: 65, pid: 's-m-2', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 38, pid: 's-m-3', type: 'indexer' },
+          { database: 'shard1', design_document: ':staged:medic', progress: 49, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard2', design_document: ':staged:medic', progress: 65, pid: 's-m-2', type: 'indexer' },
+          { database: 'shard3', design_document: ':staged:medic', progress: 38, pid: 's-m-3', type: 'indexer' },
 
-          { database: 'shard/1/medic', design_document: '_design/:staged:medic-client', progress: 65, pid: 's-mc-1', type: 'indexer' },
-          { database: 'shard/2/medic', design_document: '_design/:staged:medic-client', progress: 72, pid: 's-mc-2', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/:staged:medic-client', progress: 81, pid: 's-mc-3', type: 'indexer' },
+          { database: 'shard1', design_document: ':staged:medic-client', progress: 65, pid: 's-mc-1', type: 'indexer' },
+          { database: 'shard2', design_document: ':staged:medic-client', progress: 72, pid: 's-mc-2', type: 'indexer' },
+          { database: 'shard3', design_document: ':staged:medic-client', progress: 81, pid: 's-mc-3', type: 'indexer' },
         ],
         [
-          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 72, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard/2/medic', design_document: '_design/:staged:medic', progress: 92, pid: 's-m-2', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 75, pid: 's-m-3', type: 'indexer' },
+          { database: 'shard1', design_document: ':staged:medic', progress: 72, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard2', design_document: ':staged:medic', progress: 92, pid: 's-m-2', type: 'indexer' },
+          { database: 'shard3', design_document: ':staged:medic', progress: 75, pid: 's-m-3', type: 'indexer' },
 
-          { database: 'shard/1/medic', design_document: '_design/:staged:medic-client', progress: 93, pid: 's-mc-1', type: 'indexer' },
-          { database: 'shard/2/medic', design_document: '_design/:staged:medic-client', progress: 97, pid: 's-mc-2', type: 'indexer' },
+          { database: 'shard1', design_document: ':staged:medic-client', progress: 93, pid: 's-mc-1', type: 'indexer' },
+          { database: 'shard2', design_document: ':staged:medic-client', progress: 97, pid: 's-mc-2', type: 'indexer' },
         ],
         [
-          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 92, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 94, pid: 's-m-3', type: 'indexer' },
+          { database: 'shard1', design_document: ':staged:medic', progress: 92, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard3', design_document: ':staged:medic', progress: 94, pid: 's-m-3', type: 'indexer' },
         ],
         []
       ];
@@ -253,7 +253,7 @@ describe('Installation flow', () => {
 
       DB.app.allDocs.resolves({ rows: [
           { doc: {
-              _id: '_design/:staged:some-views',
+              _id: ':staged:some-views',
               views: {
                 a_view: 'the map etc'
               }
@@ -279,12 +279,12 @@ describe('Installation flow', () => {
         deployDoc.log.length.should.equal(1);
         deployDoc.log[0].indexers.should.deep.equal([
           {
-            design_document: '_design/:staged:medic',
+            design_document: ':staged:medic',
             progress: 100,
             tasks: { 's-m-1': 100, 's-m-2': 100, 's-m-3': 100 }
           },
           {
-            design_document: '_design/:staged:medic-client',
+            design_document: ':staged:medic-client',
             progress: 100,
             tasks: { 's-mc-1': 100, 's-mc-2': 100, 's-mc-3': 100 }
           }
@@ -295,12 +295,12 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: '_design/:staged:medic',
+              design_document: ':staged:medic',
               progress: 3,
               tasks: { 's-m-1': 3, 's-m-2': 4, 's-m-3': 2 }
             },
             {
-              design_document: '_design/:staged:medic-client',
+              design_document: ':staged:medic-client',
               progress: 7,
               tasks: { 's-mc-1': 7, 's-mc-2': 10, 's-mc-3': 5 }
             }
@@ -311,12 +311,12 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: '_design/:staged:medic',
+              design_document: ':staged:medic',
               progress: 23,
               tasks: { 's-m-1': 22, 's-m-2': 29, 's-m-3': 18 }
             },
             {
-              design_document: '_design/:staged:medic-client',
+              design_document: ':staged:medic-client',
               progress: 44,
               tasks: { 's-mc-1': 36, 's-mc-2': 41, 's-mc-3': 55 }
             }
@@ -327,12 +327,12 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: '_design/:staged:medic',
+              design_document: ':staged:medic',
               progress: 51,
               tasks: { 's-m-1': 49, 's-m-2': 65, 's-m-3': 38 }
             },
             {
-              design_document: '_design/:staged:medic-client',
+              design_document: ':staged:medic-client',
               progress: 73,
               tasks: { 's-mc-1': 65, 's-mc-2': 72, 's-mc-3': 81 }
             }
@@ -343,12 +343,12 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: '_design/:staged:medic',
+              design_document: ':staged:medic',
               progress: 80,
               tasks: { 's-m-1': 72, 's-m-2': 92, 's-m-3': 75 }
             },
             {
-              design_document: '_design/:staged:medic-client',
+              design_document: ':staged:medic-client',
               progress: 97,
               tasks: { 's-mc-1': 93, 's-mc-2': 97, 's-mc-3': 100 }
             }
@@ -359,12 +359,12 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: '_design/:staged:medic',
+              design_document: ':staged:medic',
               progress: 95,
               tasks: { 's-m-1': 92, 's-m-2': 100, 's-m-3': 94 }
             },
             {
-              design_document: '_design/:staged:medic-client',
+              design_document: ':staged:medic-client',
               progress: 100,
               tasks: { 's-mc-1': 100, 's-mc-2': 100, 's-mc-3': 100 }
             }
@@ -375,12 +375,12 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: '_design/:staged:medic',
+              design_document: ':staged:medic',
               progress: 100,
               tasks: { 's-m-1': 100, 's-m-2': 100, 's-m-3': 100 }
             },
             {
-              design_document: '_design/:staged:medic-client',
+              design_document: ':staged:medic-client',
               progress: 100,
               tasks: { 's-mc-1': 100, 's-mc-2': 100, 's-mc-3': 100 }
             }

--- a/tests/install.js
+++ b/tests/install.js
@@ -124,6 +124,7 @@ describe('Installation flow', () => {
   describe('Warming views', () => {
     it('Finds all staged ddocs and queries a view from each, writing progress to the deployDoc', () => {
       const relevantIndexer = {
+        "node": "couchdb@localhost",
         "changes_done": 5454,
         "database": "shards/80000000-ffffffff/medic.1525076838",
         "design_document": "_design/:staged:medic",
@@ -135,6 +136,7 @@ describe('Installation flow', () => {
         "updated_on": 1376116651
       };
       const irrelevantIndexer = {
+        "node": "couchdb@localhost",
         "changes_done": 5454,
         "database": "shards/80000000-ffffffff/medic.1525076838",
         "design_document": "_design/medic",
@@ -191,63 +193,62 @@ describe('Installation flow', () => {
             design_document: '_design/:staged:medic',
             progress: 100,
             tasks: {
-              '<0.6838.4>': 100
+              'couchdb@localhost-<0.6838.4>': 100
             }
           }]
         });
-        DB.activeTasks.callCount.should.equal(2);
+        DB.activeTasks.callCount.should.equal(1);
       });
     });
 
     it('Groups active tasks by ddoc and calculates an overall progress', () => {
       const indexers = [
         [
-          { database: 'shard1', design_document: ':staged:medic', progress: 3, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard2', design_document: ':staged:medic', progress: 4, pid: 's-m-2', type: 'indexer' },
-          { database: 'shard3', design_document: ':staged:medic', progress: 2, pid: 's-m-3', type: 'indexer' },
+          {database: 's1', node: 'n1', design_document: ':staged:ddoc1', progress: 3, pid: 's-d1-1', type: 'indexer'},
+          {database: 's2', node: 'n1', design_document: ':staged:ddoc1', progress: 4, pid: 's-d1-2', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: ':staged:ddoc1', progress: 2, pid: 's-d1-3', type: 'indexer'},
 
-          { database: 'shard1', design_document: ':staged:medic-client', progress: 7, pid: 's-mc-1', type: 'indexer' },
-          { database: 'shard2', design_document: ':staged:medic-client', progress: 10, pid: 's-mc-2', type: 'indexer' },
-          { database: 'shard3', design_document: ':staged:medic-client', progress: 5, pid: 's-mc-3', type: 'indexer' },
+          {database: 's1', node: 'n1', design_document: ':staged:ddoc2', progress: 7, pid: 's-d2-1', type: 'indexer'},
+          {database: 's2', node: 'n1', design_document: ':staged:ddoc2', progress: 10, pid: 's-d2-2', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: ':staged:ddoc2', progress: 5, pid: 's-d2-3', type: 'indexer'},
 
-          { database: 'shard1', design_document: 'medic', progress: 77, pid: 'm-1', type: 'indexer' },
-          { database: 'shard2', design_document: 'medic', progress: 99, pid: 'm-2', type: 'indexer' },
-          { database: 'shard3', design_document: 'medic', progress: 52, pid: 'm-3', type: 'indexer' },
+          {database: 's1', node: 'n1', design_document: 'ddoc1', progress: 77, pid: 'd1-1', type: 'indexer'},
+          {database: 's2', node: 'n1', design_document: 'ddoc1', progress: 99, pid: 'd1-2', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: 'ddoc1', progress: 52, pid: 'd1-3', type: 'indexer'},
         ],
         [
-          { database: 'shard1', design_document: ':staged:medic', progress: 22, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard2', design_document: ':staged:medic', progress: 29, pid: 's-m-2', type: 'indexer' },
-          { database: 'shard3', design_document: ':staged:medic', progress: 18, pid: 's-m-3', type: 'indexer'},
+          {database: 's1', node: 'n1', design_document: ':staged:ddoc1', progress: 22, pid: 's-d1-1', type: 'indexer'},
+          {database: 's2', node: 'n1', design_document: ':staged:ddoc1', progress: 29, pid: 's-d1-2', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: ':staged:ddoc1', progress: 18, pid: 's-d1-3', type: 'indexer'},
 
-          { database: 'shard1', design_document: ':staged:medic-client', progress: 36, pid: 's-mc-1', type: 'indexer' },
-          { database: 'shard2', design_document: ':staged:medic-client', progress: 41, pid: 's-mc-2', type: 'indexer' },
-          { database: 'shard3', design_document: ':staged:medic-client', progress: 55, pid: 's-mc-3', type: 'indexer' },
+          {database: 's1', node: 'n1', design_document: ':staged:ddoc2', progress: 36, pid: 's-d2-1', type: 'indexer'},
+          {database: 's2', node: 'n1', design_document: ':staged:ddoc2', progress: 41, pid: 's-d2-2', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: ':staged:ddoc2', progress: 55, pid: 's-d2-3', type: 'indexer'},
 
-          { database: 'shard1', design_document: 'medic', progress: 87, pid: 'm-1', type: 'indexer' },
-          { database: 'shard3', design_document: 'medic', progress: 95, pid: 'm-3', type: 'indexer' },
+          {database: 's1', node: 'n1', design_document: 'ddoc1', progress: 87, pid: 'd1-1', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: 'ddoc1', progress: 95, pid: 'd1-3', type: 'indexer'},
         ],
         [
-          { database: 'shard1', design_document: ':staged:medic', progress: 49, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard2', design_document: ':staged:medic', progress: 65, pid: 's-m-2', type: 'indexer' },
-          { database: 'shard3', design_document: ':staged:medic', progress: 38, pid: 's-m-3', type: 'indexer' },
+          {database: 's1', node: 'n1', design_document: ':staged:ddoc1', progress: 49, pid: 's-d1-1', type: 'indexer'},
+          {database: 's2', node: 'n1', design_document: ':staged:ddoc1', progress: 65, pid: 's-d1-2', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: ':staged:ddoc1', progress: 38, pid: 's-d1-3', type: 'indexer'},
 
-          { database: 'shard1', design_document: ':staged:medic-client', progress: 65, pid: 's-mc-1', type: 'indexer' },
-          { database: 'shard2', design_document: ':staged:medic-client', progress: 72, pid: 's-mc-2', type: 'indexer' },
-          { database: 'shard3', design_document: ':staged:medic-client', progress: 81, pid: 's-mc-3', type: 'indexer' },
+          {database: 's1', node: 'n1', design_document: ':staged:ddoc2', progress: 65, pid: 's-d2-1', type: 'indexer'},
+          {database: 's2', node: 'n1', design_document: ':staged:ddoc2', progress: 72, pid: 's-d2-2', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: ':staged:ddoc2', progress: 81, pid: 's-d2-3', type: 'indexer'},
         ],
         [
-          { database: 'shard1', design_document: ':staged:medic', progress: 72, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard2', design_document: ':staged:medic', progress: 92, pid: 's-m-2', type: 'indexer' },
-          { database: 'shard3', design_document: ':staged:medic', progress: 75, pid: 's-m-3', type: 'indexer' },
+          {database: 's1', node: 'n1', design_document: ':staged:ddoc1', progress: 72, pid: 's-d1-1', type: 'indexer'},
+          {database: 's2', node: 'n1', design_document: ':staged:ddoc1', progress: 92, pid: 's-d1-2', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: ':staged:ddoc1', progress: 75, pid: 's-d1-3', type: 'indexer'},
 
-          { database: 'shard1', design_document: ':staged:medic-client', progress: 93, pid: 's-mc-1', type: 'indexer' },
-          { database: 'shard2', design_document: ':staged:medic-client', progress: 97, pid: 's-mc-2', type: 'indexer' },
+          {database: 's1', node: 'n1', design_document: ':staged:ddoc2', progress: 93, pid: 's-d2-1', type: 'indexer'},
+          {database: 's2', node: 'n1', design_document: ':staged:ddoc2', progress: 97, pid: 's-d2-2', type: 'indexer'},
         ],
         [
-          { database: 'shard1', design_document: ':staged:medic', progress: 92, pid: 's-m-1', type: 'indexer' },
-          { database: 'shard3', design_document: ':staged:medic', progress: 94, pid: 's-m-3', type: 'indexer' },
-        ],
-        []
+          {database: 's1', node: 'n1', design_document: ':staged:ddoc1', progress: 92, pid: 's-d1-1', type: 'indexer'},
+          {database: 's3', node: 'n1', design_document: ':staged:ddoc1', progress: 94, pid: 's-d1-3', type: 'indexer'},
+        ]
       ];
       const deployDocs = [];
 
@@ -272,21 +273,21 @@ describe('Installation flow', () => {
       });
 
       return install._warmViews(deployDoc).then(() => {
-        DB.activeTasks.callCount.should.equal(6);
+        DB.activeTasks.callCount.should.equal(5);
         DB.app.query.callCount.should.equal(5);
         utils.update.callCount.should.equal(7);
 
         deployDoc.log.length.should.equal(1);
         deployDoc.log[0].indexers.should.deep.equal([
           {
-            design_document: ':staged:medic',
+            design_document: ':staged:ddoc1',
             progress: 100,
-            tasks: { 's-m-1': 100, 's-m-2': 100, 's-m-3': 100 }
+            tasks: { 'n1-s-d1-1': 100, 'n1-s-d1-2': 100, 'n1-s-d1-3': 100 }
           },
           {
-            design_document: ':staged:medic-client',
+            design_document: ':staged:ddoc2',
             progress: 100,
-            tasks: { 's-mc-1': 100, 's-mc-2': 100, 's-mc-3': 100 }
+            tasks: { 'n1-s-d2-1': 100, 'n1-s-d2-2': 100, 'n1-s-d2-3': 100 }
           }
         ]);
 
@@ -295,14 +296,14 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: ':staged:medic',
+              design_document: ':staged:ddoc1',
               progress: 3,
-              tasks: { 's-m-1': 3, 's-m-2': 4, 's-m-3': 2 }
+              tasks: { 'n1-s-d1-1': 3, 'n1-s-d1-2': 4, 'n1-s-d1-3': 2 }
             },
             {
-              design_document: ':staged:medic-client',
+              design_document: ':staged:ddoc2',
               progress: 7,
-              tasks: { 's-mc-1': 7, 's-mc-2': 10, 's-mc-3': 5 }
+              tasks: { 'n1-s-d2-1': 7, 'n1-s-d2-2': 10, 'n1-s-d2-3': 5 }
             }
           ]
         }]);
@@ -311,14 +312,14 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: ':staged:medic',
+              design_document: ':staged:ddoc1',
               progress: 23,
-              tasks: { 's-m-1': 22, 's-m-2': 29, 's-m-3': 18 }
+              tasks: { 'n1-s-d1-1': 22, 'n1-s-d1-2': 29, 'n1-s-d1-3': 18 }
             },
             {
-              design_document: ':staged:medic-client',
+              design_document: ':staged:ddoc2',
               progress: 44,
-              tasks: { 's-mc-1': 36, 's-mc-2': 41, 's-mc-3': 55 }
+              tasks: { 'n1-s-d2-1': 36, 'n1-s-d2-2': 41, 'n1-s-d2-3': 55 }
             }
           ]
         }]);
@@ -327,14 +328,14 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: ':staged:medic',
+              design_document: ':staged:ddoc1',
               progress: 51,
-              tasks: { 's-m-1': 49, 's-m-2': 65, 's-m-3': 38 }
+              tasks: { 'n1-s-d1-1': 49, 'n1-s-d1-2': 65, 'n1-s-d1-3': 38 }
             },
             {
-              design_document: ':staged:medic-client',
+              design_document: ':staged:ddoc2',
               progress: 73,
-              tasks: { 's-mc-1': 65, 's-mc-2': 72, 's-mc-3': 81 }
+              tasks: { 'n1-s-d2-1': 65, 'n1-s-d2-2': 72, 'n1-s-d2-3': 81 }
             }
           ]
         }]);
@@ -343,14 +344,14 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: ':staged:medic',
+              design_document: ':staged:ddoc1',
               progress: 80,
-              tasks: { 's-m-1': 72, 's-m-2': 92, 's-m-3': 75 }
+              tasks: { 'n1-s-d1-1': 72, 'n1-s-d1-2': 92, 'n1-s-d1-3': 75 }
             },
             {
-              design_document: ':staged:medic-client',
+              design_document: ':staged:ddoc2',
               progress: 97,
-              tasks: { 's-mc-1': 93, 's-mc-2': 97, 's-mc-3': 100 }
+              tasks: { 'n1-s-d2-1': 93, 'n1-s-d2-2': 97, 'n1-s-d2-3': 100 }
             }
           ]
         }]);
@@ -359,14 +360,14 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: ':staged:medic',
+              design_document: ':staged:ddoc1',
               progress: 95,
-              tasks: { 's-m-1': 92, 's-m-2': 100, 's-m-3': 94 }
+              tasks: { 'n1-s-d1-1': 92, 'n1-s-d1-2': 100, 'n1-s-d1-3': 94 }
             },
             {
-              design_document: ':staged:medic-client',
+              design_document: ':staged:ddoc2',
               progress: 100,
-              tasks: { 's-mc-1': 100, 's-mc-2': 100, 's-mc-3': 100 }
+              tasks: { 'n1-s-d2-1': 100, 'n1-s-d2-2': 100, 'n1-s-d2-3': 100 }
             }
           ]
         }]);
@@ -375,14 +376,14 @@ describe('Installation flow', () => {
           type: 'warm_log',
           indexers: [
             {
-              design_document: ':staged:medic',
+              design_document: ':staged:ddoc1',
               progress: 100,
-              tasks: { 's-m-1': 100, 's-m-2': 100, 's-m-3': 100 }
+              tasks: { 'n1-s-d1-1': 100, 'n1-s-d1-2': 100, 'n1-s-d1-3': 100 }
             },
             {
-              design_document: ':staged:medic-client',
+              design_document: ':staged:ddoc2',
               progress: 100,
-              tasks: { 's-mc-1': 100, 's-mc-2': 100, 's-mc-3': 100 }
+              tasks: { 'n1-s-d2-1': 100, 'n1-s-d2-2': 100, 'n1-s-d2-3': 100 }
             }
           ]
         }]);

--- a/tests/install.js
+++ b/tests/install.js
@@ -171,6 +171,7 @@ describe('Installation flow', () => {
       DB.app.query.resolves();
       DB.app.put.resolves({});
       DB.activeTasks.resolves([relevantIndexer, irrelevantIndexer]);
+      DB.activeTasks.onCall(1).resolves([]);
 
       return install._warmViews(deployDoc)
         .then(() => {
@@ -181,12 +182,211 @@ describe('Installation flow', () => {
         DB.app.query.args[1][0].should.equal(':staged:some-more-views/yet_another_view');
 
         // First to init the warm log, second after querying for indexes
-        DB.app.put.callCount.should.equal(2);
+        // third after all views are warmed
+        DB.app.put.callCount.should.equal(3);
         DB.app.put.args[1][0].log.length.should.equal(1);
         DB.app.put.args[1][0].log[0].should.deep.equal({
           type: 'warm_log',
-          indexers: [relevantIndexer]
+          indexers: [{
+            design_document: '_design/:staged:medic',
+            progress: 100,
+            tasks: {
+              '<0.6838.4>': 100
+            }
+          }]
         });
+        DB.activeTasks.callCount.should.equal(2);
+      });
+    });
+
+    it('Groups active tasks by ddoc and calculates an overall progress', () => {
+      const indexers = [
+        [
+          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 3, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard/2/medic', design_document: '_design/:staged:medic', progress: 4, pid: 's-m-2', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 2, pid: 's-m-3', type: 'indexer' },
+
+          { database: 'shard/1/medic', design_document: '_design/:staged:medic-client', progress: 7, pid: 's-mc-1', type: 'indexer' },
+          { database: 'shard/2/medic', design_document: '_design/:staged:medic-client', progress: 10, pid: 's-mc-2', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/:staged:medic-client', progress: 5, pid: 's-mc-3', type: 'indexer' },
+
+          { database: 'shard/1/medic', design_document: '_design/medic', progress: 77, pid: 'm-1', type: 'indexer' },
+          { database: 'shard/2/medic', design_document: '_design/medic', progress: 99, pid: 'm-2', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/medic', progress: 52, pid: 'm-3', type: 'indexer' },
+        ],
+        [
+          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 22, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard/2/medic', design_document: '_design/:staged:medic', progress: 29, pid: 's-m-2', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 18, pid: 's-m-3', type: 'indexer'},
+
+          { database: 'shard/1/medic', design_document: '_design/:staged:medic-client', progress: 36, pid: 's-mc-1', type: 'indexer' },
+          { database: 'shard/2/medic', design_document: '_design/:staged:medic-client', progress: 41, pid: 's-mc-2', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/:staged:medic-client', progress: 55, pid: 's-mc-3', type: 'indexer' },
+
+          { database: 'shard/1/medic', design_document: '_design/medic', progress: 87, pid: 'm-1', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/medic', progress: 95, pid: 'm-3', type: 'indexer' },
+        ],
+        [
+          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 49, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard/2/medic', design_document: '_design/:staged:medic', progress: 65, pid: 's-m-2', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 38, pid: 's-m-3', type: 'indexer' },
+
+          { database: 'shard/1/medic', design_document: '_design/:staged:medic-client', progress: 65, pid: 's-mc-1', type: 'indexer' },
+          { database: 'shard/2/medic', design_document: '_design/:staged:medic-client', progress: 72, pid: 's-mc-2', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/:staged:medic-client', progress: 81, pid: 's-mc-3', type: 'indexer' },
+        ],
+        [
+          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 72, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard/2/medic', design_document: '_design/:staged:medic', progress: 92, pid: 's-m-2', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 75, pid: 's-m-3', type: 'indexer' },
+
+          { database: 'shard/1/medic', design_document: '_design/:staged:medic-client', progress: 93, pid: 's-mc-1', type: 'indexer' },
+          { database: 'shard/2/medic', design_document: '_design/:staged:medic-client', progress: 97, pid: 's-mc-2', type: 'indexer' },
+        ],
+        [
+          { database: 'shard/1/medic', design_document: '_design/:staged:medic', progress: 92, pid: 's-m-1', type: 'indexer' },
+          { database: 'shard/3/medic', design_document: '_design/:staged:medic', progress: 94, pid: 's-m-3', type: 'indexer' },
+        ],
+        []
+      ];
+      const deployDocs = [];
+
+      DB.app.allDocs.resolves({ rows: [
+          { doc: {
+              _id: '_design/:staged:some-views',
+              views: {
+                a_view: 'the map etc'
+              }
+            }}
+        ]});
+
+      DB.app.query.rejects({ code: 'ESOCKETTIMEDOUT' });
+      DB.app.query.onCall(4).resolves();
+      indexers.forEach((indexer, key) => {
+        DB.activeTasks.onCall(key).resolves(indexer);
+      });
+      deployDoc.log = [];
+      sinon.stub(utils, 'update').callsFake(doc => {
+        deployDocs.push(JSON.parse(JSON.stringify(doc)));
+        return Promise.resolve();
+      });
+
+      return install._warmViews(deployDoc).then(() => {
+        DB.activeTasks.callCount.should.equal(6);
+        DB.app.query.callCount.should.equal(5);
+        utils.update.callCount.should.equal(7);
+
+        deployDoc.log.length.should.equal(1);
+        deployDoc.log[0].indexers.should.deep.equal([
+          {
+            design_document: '_design/:staged:medic',
+            progress: 100,
+            tasks: { 's-m-1': 100, 's-m-2': 100, 's-m-3': 100 }
+          },
+          {
+            design_document: '_design/:staged:medic-client',
+            progress: 100,
+            tasks: { 's-mc-1': 100, 's-mc-2': 100, 's-mc-3': 100 }
+          }
+        ]);
+
+        deployDocs[0].log.should.deep.equal([{ type: 'warm_log' }]);
+        deployDocs[1].log.should.deep.equal([{
+          type: 'warm_log',
+          indexers: [
+            {
+              design_document: '_design/:staged:medic',
+              progress: 3,
+              tasks: { 's-m-1': 3, 's-m-2': 4, 's-m-3': 2 }
+            },
+            {
+              design_document: '_design/:staged:medic-client',
+              progress: 7,
+              tasks: { 's-mc-1': 7, 's-mc-2': 10, 's-mc-3': 5 }
+            }
+          ]
+        }]);
+
+        deployDocs[2].log.should.deep.equal([{
+          type: 'warm_log',
+          indexers: [
+            {
+              design_document: '_design/:staged:medic',
+              progress: 23,
+              tasks: { 's-m-1': 22, 's-m-2': 29, 's-m-3': 18 }
+            },
+            {
+              design_document: '_design/:staged:medic-client',
+              progress: 44,
+              tasks: { 's-mc-1': 36, 's-mc-2': 41, 's-mc-3': 55 }
+            }
+          ]
+        }]);
+
+        deployDocs[3].log.should.deep.equal([{
+          type: 'warm_log',
+          indexers: [
+            {
+              design_document: '_design/:staged:medic',
+              progress: 51,
+              tasks: { 's-m-1': 49, 's-m-2': 65, 's-m-3': 38 }
+            },
+            {
+              design_document: '_design/:staged:medic-client',
+              progress: 73,
+              tasks: { 's-mc-1': 65, 's-mc-2': 72, 's-mc-3': 81 }
+            }
+          ]
+        }]);
+
+        deployDocs[4].log.should.deep.equal([{
+          type: 'warm_log',
+          indexers: [
+            {
+              design_document: '_design/:staged:medic',
+              progress: 80,
+              tasks: { 's-m-1': 72, 's-m-2': 92, 's-m-3': 75 }
+            },
+            {
+              design_document: '_design/:staged:medic-client',
+              progress: 97,
+              tasks: { 's-mc-1': 93, 's-mc-2': 97, 's-mc-3': 100 }
+            }
+          ]
+        }]);
+
+        deployDocs[5].log.should.deep.equal([{
+          type: 'warm_log',
+          indexers: [
+            {
+              design_document: '_design/:staged:medic',
+              progress: 95,
+              tasks: { 's-m-1': 92, 's-m-2': 100, 's-m-3': 94 }
+            },
+            {
+              design_document: '_design/:staged:medic-client',
+              progress: 100,
+              tasks: { 's-mc-1': 100, 's-mc-2': 100, 's-mc-3': 100 }
+            }
+          ]
+        }]);
+
+        deployDocs[6].log.should.deep.equal([{
+          type: 'warm_log',
+          indexers: [
+            {
+              design_document: '_design/:staged:medic',
+              progress: 100,
+              tasks: { 's-m-1': 100, 's-m-2': 100, 's-m-3': 100 }
+            },
+            {
+              design_document: '_design/:staged:medic-client',
+              progress: 100,
+              tasks: { 's-mc-1': 100, 's-mc-2': 100, 's-mc-3': 100 }
+            }
+          ]
+        }]);
+
       });
     });
   });

--- a/tests/install.js
+++ b/tests/install.js
@@ -173,7 +173,6 @@ describe('Installation flow', () => {
       DB.app.query.resolves();
       DB.app.put.resolves({});
       DB.activeTasks.resolves([relevantIndexer, irrelevantIndexer]);
-      DB.activeTasks.onCall(1).resolves([]);
 
       return install._warmViews(deployDoc)
         .then(() => {


### PR DESCRIPTION
Instead of overwriting view indexer logs on every run, it groups `_active_tasks` output by ddoc and calculates average progress of all individual tasks. When a task is no longer present in `_active_tasks` output, it is assumed that it has finished. 

medic/medic-webapp#4567