### PR TITLE
Updating deployment steps order to reduce restart time

### DIFF
--- a/src/apps.js
+++ b/src/apps.js
@@ -3,47 +3,43 @@ const debug = require('./log').debug;
 
 const APPS = [ 'medic-api', 'medic-sentinel' ];
 
+const execForApp = (cmd, app) => {
+  cmd = cmd.map(sub => sub.replace(/{{app}}/g, app));
 
-module.exports = (startCmd, stopCmd) => {
-
-  const execForApp = (cmd, app) => {
-    cmd = cmd.map(sub => sub.replace(/{{app}}/g, app));
-
-    return new Promise((resolve, reject) => {
-      const proc = child_process.spawn(cmd.shift(), cmd, {
-        stdio: [ 'ignore', process.stdout, process.stderr ],
-      });
-
-      proc.on('close', status => status ? reject(`${app} existed with status ${status}`) : resolve());
+  return new Promise((resolve, reject) => {
+    const proc = child_process.spawn(cmd.shift(), cmd, {
+      stdio: [ 'ignore', process.stdout, process.stderr ],
     });
-  };
 
-  const startApps = () =>
-    APPS.reduce(
-        (p, app) => p
-          .then(() => debug(`Starting app: ${app} with command: ${startCmd}…`))
-          .then(() => execForApp(startCmd, app))
-          .then(() => debug(`Started ${app} in the background.`)),
-        Promise.resolve());
+    proc.on('close', status => status ? reject(`${app} existed with status ${status}`) : resolve());
+  });
+};
 
-  const stopApps = () =>
-    APPS.reduce(
-        (p, app) => p
-          .then(() => debug(`Stopping app: ${app} with command: ${startCmd}…`))
-          .then(() => execForApp(stopCmd, app))
-          .then(() => debug(`Stopped ${app}.`)),
-        Promise.resolve());
+const startApps = (cmd) =>
+  APPS.reduce(
+      (p, app) => p
+        .then(() => debug(`Starting app: ${app} with command: ${cmd}…`))
+        .then(() => execForApp(cmd, app))
+        .then(() => debug(`Started ${app} in the background.`)),
+      Promise.resolve());
 
-  const stopSync = () => {
-    APPS.forEach(app => {
-      execForApp(stopCmd, app);
-    });
-  };
+const stopApps = (cmd) =>
+  APPS.reduce(
+      (p, app) => p
+        .then(() => debug(`Stopping app: ${app} with command: ${cmd}…`))
+        .then(() => execForApp(cmd, app))
+        .then(() => debug(`Stopped ${app}.`)),
+      Promise.resolve());
 
-  return {
-    APPS: APPS,
-    start: startApps,
-    stop: stopApps,
-    stopSync: stopSync,
-  };
+const stopSync = (cmd) => {
+  APPS.forEach(app => {
+    execForApp(cmd, app);
+  });
+};
+
+module.exports = {
+  APPS: APPS,
+  start: (cmd) => startApps(cmd),
+  stop: (cmd) => stopApps(cmd),
+  stopSync: (cmd) => stopSync(cmd),
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,7 @@
 const fs = require('fs-extra'),
       os = require('os'),
       parseArgs = require('minimist'),
-      onExit = require('signal-exit'),
-      apps = require('./apps');
+      onExit = require('signal-exit');
 
 const { error, info } = require('./log');
 
@@ -13,7 +12,8 @@ const daemon = require('./daemon'),
       bootstrap = require('./bootstrap'),
       fatality = require('./fatality'),
       help = require('./help'),
-      lockfile = require('./lockfile');
+      lockfile = require('./lockfile'),
+      apps = require('./apps');
 
 const MODES = {
   development: {

--- a/src/index.js
+++ b/src/index.js
@@ -2,14 +2,14 @@
 const fs = require('fs-extra'),
       os = require('os'),
       parseArgs = require('minimist'),
-      onExit = require('signal-exit');
+      onExit = require('signal-exit'),
+      apps = require('./apps');
 
 const { error, info } = require('./log');
 
 const { ACTIONS } = require('./constants');
 
-const appUtils = require('./apps'),
-      daemon = require('./daemon'),
+const daemon = require('./daemon'),
       bootstrap = require('./bootstrap'),
       fatality = require('./fatality'),
       help = require('./help'),
@@ -59,7 +59,6 @@ const mode = argv.dev         ? MODES.development :
              argv.local       ? MODES.local :
              argv['medic-os'] ? MODES.medic_os :
              undefined;
-const apps = appUtils(mode.start, mode.stop);
 
 if (argv.version || argv.v) {
   help.outputVersion();
@@ -104,7 +103,7 @@ process.on('uncaughtException', fatality);
 // clearing of the lockfile is handled by the lockfile library itself
 onExit((code) => {
   if (mode.manageAppLifecycle && mode.daemon) {
-    apps.stopSync();
+    apps.stopSync(mode.stop);
   }
 
   process.exit(code || 0);
@@ -126,6 +125,6 @@ lockfile.wait()
       return bootstrap.existing();
     }
   }).then(deployDoc => {
-      return daemon.init(deployDoc, mode, apps);
+      return daemon.init(deployDoc, mode);
   })
   .catch(fatality);

--- a/src/install/app.js
+++ b/src/install/app.js
@@ -1,0 +1,17 @@
+const path = require('path');
+
+module.exports = (module, digest, mode) => {
+  const name = module.substring(0, module.lastIndexOf('-'));
+
+  const deployPath = (identifier) => {
+    identifier = identifier || digest.replace(/\//g, '');
+    return path.resolve(path.join(mode.deployments, name, identifier));
+  };
+
+  return {
+    name: name,
+    attachmentName: module,
+    digest: digest,
+    deployPath: (identifier) => deployPath(identifier)
+  };
+};

--- a/src/install/ddocWrapper.js
+++ b/src/install/ddocWrapper.js
@@ -1,0 +1,55 @@
+const decompress = require('decompress');
+const fs = require('fs-extra');
+const { debug } = require('../log');
+const app = require('./app');
+
+module.exports = (ddoc, mode) => {
+
+  const moduleToApp = module => {
+    if (!ddoc._attachments[module]) {
+      throw Error(`${module} was specified in build_info.node_modules but is not attached`);
+    }
+
+    return app(module, ddoc._attachments[module].digest, mode);
+  };
+
+  const appNotAlreadyUnzipped = app => !fs.existsSync(app.deployPath());
+
+  const getChangedApps = () => {
+    let changedApps = [];
+    if (ddoc.node_modules) {
+      // Legacy Kanso data location
+      changedApps = ddoc.node_modules
+              .split(',')
+              .map(module => moduleToApp(module));
+    } else if (ddoc.build_info) {
+      // New horticulturalist layout
+      changedApps = ddoc.build_info.node_modules
+              .map(module => moduleToApp(module));
+    }
+
+    debug(`Found ${JSON.stringify(changedApps)}`);
+    changedApps = changedApps.filter(appNotAlreadyUnzipped);
+    debug(`Apps that aren't unzipped: ${JSON.stringify(changedApps)}`);
+
+    return changedApps;
+  };
+
+  const unzipChangedApps = (changedApps) =>
+    Promise.all(changedApps.map(app => {
+      const attachment = ddoc._attachments[app.attachmentName].data;
+      return decompress(attachment, app.deployPath(), {
+        map: file => {
+          file.path = file.path.replace(/^package/, '');
+          return file;
+        }
+      });
+    }));
+
+  return {
+    ddoc: ddoc,
+    mode: mode,
+    getChangedApps: () => getChangedApps(),
+    unzipChangedApps: (apps) => unzipChangedApps(apps)
+  };
+};

--- a/src/install/deploySteps.js
+++ b/src/install/deploySteps.js
@@ -120,7 +120,8 @@ module.exports = (mode, deployDoc) => {
   };
 
   const processDdoc = (ddoc, firstRun) => {
-    const changedApps = ddoc.getChangedApps();
+    const wrappedDdoc = ddocWrapper(ddoc);
+    const changedApps = wrappedDdoc.getChangedApps();
     const appsToDeploy = changedApps.length;
 
     return Promise.resolve()
@@ -128,7 +129,7 @@ module.exports = (mode, deployDoc) => {
         if (appsToDeploy) {
           return Promise.resolve()
             .then(() => info(`Unzipping changed apps to ${mode.deployments}…`, changedApps))
-            .then(() => ddoc.unzipChangedApps(changedApps))
+            .then(() => wrappedDdoc.unzipChangedApps(changedApps))
             .then(() => info('Changed apps unzipped.'))
             .then(() => {
               if (mode.daemon) {
@@ -165,7 +166,7 @@ module.exports = (mode, deployDoc) => {
 
   const moduleWithContext = {
     run: (ddoc, firstRun) => {
-      return processDdoc(ddocWrapper(ddoc), firstRun);
+      return processDdoc(ddoc, firstRun);
     },
     _deployStagedDdocs: deployStagedDdocs,
     _loadStagedDdocs: loadStagedDdocs,

--- a/src/install/deploySteps.js
+++ b/src/install/deploySteps.js
@@ -1,72 +1,17 @@
-const decompress = require('decompress'),
-      fs = require('fs-extra'),
-      path = require('path');
+const fs = require('fs-extra'),
+      apps = require('../apps'),
+      ddocWrapper = require('./ddocWrapper');
 
 const { info, debug } = require('../log'),
       DB = require('../dbs');
 
 const utils = require('../utils');
 
-module.exports = (apps, mode, deployDoc) => {
-  const appNameFromModule = module =>
-    module.substring(0, module.lastIndexOf('-'));
+module.exports = (mode, deployDoc) => {
 
-  const deployPath = (app, identifier) => {
-    identifier = identifier || app.digest.replace(/\//g, '');
-    return path.resolve(path.join(mode.deployments, app.name, identifier));
-  };
-
-  const appNotAlreadyUnzipped = app =>
-    !fs.existsSync(deployPath(app));
-
-  const moduleToApp = (ddoc, module) => {
-    if (!ddoc._attachments[module]) {
-      throw Error(`${module} was specified in build_info.node_modules but is not attached`);
-    }
-
-    const app = {
-      name: appNameFromModule(module),
-      attachmentName: module,
-      digest: ddoc._attachments[module].digest,
-    };
-
-    return app;
-  };
-
-  const getChangedApps = ddoc => {
-    let apps = [];
-    if (ddoc.node_modules) {
-      // Legacy Kanso data location
-      apps = ddoc.node_modules
-              .split(',')
-              .map(module => moduleToApp(ddoc, module));
-    } else if (ddoc.build_info) {
-      // New horticulturalist layout
-      apps = ddoc.build_info.node_modules
-              .map(module => moduleToApp(ddoc, module));
-    }
-
-    debug(`Found ${JSON.stringify(apps)}`);
-    apps = apps.filter(appNotAlreadyUnzipped);
-    debug(`Apps that aren't unzipped: ${JSON.stringify(apps)}`);
-
-    return apps;
-  };
-
-  const unzipChangedApps = (ddoc, changedApps) =>
-    Promise.all(changedApps.map(app => {
-      const attachment = ddoc._attachments[app.attachmentName].data;
-      return decompress(attachment, deployPath(app), {
-        map: file => {
-          file.path = file.path.replace(/^package/, '');
-          return file;
-        }
-      });
-    }));
-
-  const startApps = () => {
+  const startApps = (mode) => {
     info('Starting all apps…', apps.APPS);
-    return apps.start()
+    return apps.start(mode.start)
       .then(() => info('All apps started.'));
   };
 
@@ -158,41 +103,24 @@ module.exports = (apps, mode, deployDoc) => {
 
   const updateSymlink = changedApps => {
     return Promise.all(changedApps.map(app => {
-      const livePath = deployPath(app, 'current');
+      const livePath = app.deployPath('current');
 
       if(fs.existsSync(livePath)) {
         const linkString = fs.readlinkSync(livePath);
 
         if(fs.existsSync(linkString)) {
-          fs.symlinkSync(linkString, deployPath(app, 'old'));
+          fs.symlinkSync(linkString, app.deployPath('old'));
         } else debug(`Old app not found at ${linkString}.`);
 
         fs.unlinkSync(livePath);
       }
 
-      fs.symlinkSync(deployPath(app), livePath);
-    }));
-  };
-
-  const removeOldVersion = changedApps => {
-    return Promise.all(changedApps.map(app => {
-      const oldPath = deployPath(app, 'old');
-
-      if(fs.existsSync(oldPath)) {
-        const linkString = fs.readlinkSync(oldPath);
-
-        if(fs.existsSync(linkString)) {
-          debug(`Deleting old ${app.name} from ${linkString}…`);
-          fs.removeSync(linkString);
-        } else debug(`Old app not found at ${linkString}.`);
-
-        fs.unlinkSync(oldPath);
-      }
+      fs.symlinkSync(app.deployPath(), livePath);
     }));
   };
 
   const processDdoc = (ddoc, firstRun) => {
-    const changedApps = getChangedApps(ddoc);
+    const changedApps = ddoc.getChangedApps();
     const appsToDeploy = changedApps.length;
 
     return Promise.resolve()
@@ -200,13 +128,13 @@ module.exports = (apps, mode, deployDoc) => {
         if (appsToDeploy) {
           return Promise.resolve()
             .then(() => info(`Unzipping changed apps to ${mode.deployments}…`, changedApps))
-            .then(() => unzipChangedApps(ddoc, changedApps))
+            .then(() => ddoc.unzipChangedApps(changedApps))
             .then(() => info('Changed apps unzipped.'))
             .then(() => {
               if (mode.daemon) {
                 return Promise.resolve()
                   .then(() => info('Stopping all apps…', apps.APPS))
-                  .then(() => apps.stop())
+                  .then(() => apps.stop(mode.stop))
                   .then(() => info('All apps stopped.'));
               }
             });
@@ -228,7 +156,7 @@ module.exports = (apps, mode, deployDoc) => {
 
       .then(() => {
         if (mode.daemon && (appsToDeploy || firstRun)) {
-          return startApps().then(() => {
+          return startApps(mode).then(() => {
             return changedApps;
           });
         }
@@ -237,9 +165,8 @@ module.exports = (apps, mode, deployDoc) => {
 
   const moduleWithContext = {
     run: (ddoc, firstRun) => {
-      return processDdoc(ddoc, firstRun);
+      return processDdoc(ddocWrapper(ddoc), firstRun);
     },
-    removeOldVersion: (changedApps) => removeOldVersion(changedApps),
     _deployStagedDdocs: deployStagedDdocs,
     _loadStagedDdocs: loadStagedDdocs,
     _deploySecondaryDdocs: deploySecondaryDdocs,

--- a/src/install/deploySteps.js
+++ b/src/install/deploySteps.js
@@ -146,17 +146,13 @@ module.exports = (apps, mode, deployDoc) => {
       });
   };
 
-  const deployStagedDdocs = (secondaryOnly=false) => {
+  const deployStagedDdocs = () => {
     info(`Deploying staged ddocs`);
 
     return moduleWithContext._loadStagedDdocs()
       .then(({primaryDdoc, secondaryDdocs}) => {
         return moduleWithContext._deploySecondaryDdocs(secondaryDdocs)
-          .then(() => {
-            if(!secondaryOnly) {
-              moduleWithContext._deployPrimaryDdoc(primaryDdoc);
-            }
-          });
+          .then(() => moduleWithContext._deployPrimaryDdoc(primaryDdoc));
       });
   };
 
@@ -206,7 +202,6 @@ module.exports = (apps, mode, deployDoc) => {
             .then(() => info(`Unzipping changed apps to ${mode.deployments}…`, changedApps))
             .then(() => unzipChangedApps(ddoc, changedApps))
             .then(() => info('Changed apps unzipped.'))
-            .then(() => deployStagedDdocs(true))
             .then(() => {
               if (mode.daemon) {
                 return Promise.resolve()

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -1,8 +1,8 @@
 const { info, debug, stage: stageLog } = require('../log'),
       DB = require('../dbs'),
       fs = require('fs-extra'),
-   utils = require('../utils'),
-   ddocWrapper = require('./ddocWrapper');
+      utils = require('../utils'),
+      ddocWrapper = require('./ddocWrapper');
 
 const stager = deployDoc => (key, message) => {
   stageLog(message);
@@ -273,8 +273,10 @@ const deploySteps = (mode, deployDoc, firstRun, ddoc) => {
       return stage('horti.stage.deploying', 'Deploying new installation')
         .then(() => performDeploy(mode, deployDoc, ddoc, firstRun))
         .then(() => {
-          stage('horti.stage.postCleanup', 'Post-deploy cleanup, installation complete');
-          return postCleanup(ddocWrapper(ddoc, mode), deployDoc);
+          return stage('horti.stage.postCleanup', 'Post-deploy cleanup, installation complete')
+            .then(() => {
+              return postCleanup(ddocWrapper(ddoc, mode), deployDoc);
+            });
         });
     });
 };
@@ -282,6 +284,11 @@ const deploySteps = (mode, deployDoc, firstRun, ddoc) => {
 
 
 module.exports = {
+  // TODO: when all is said and done do we still need first run?
+  //       (cause you can intuit?)
+  //  (
+  //    you know if its first run because the apps are either running or they're not
+  //  )
   install: (deployDoc, mode, firstRun) => {
     info(`Deploying new build: ${keyFromDeployDoc(deployDoc)}`);
 

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -271,13 +271,9 @@ const deploySteps = (mode, deployDoc, firstRun, ddoc) => {
     .then(getApplicationDdoc)
     .then(ddoc => {
       return stage('horti.stage.deploying', 'Deploying new installation')
-        .then(() => performDeploy(mode, deployDoc, ddoc, firstRun))
-        .then(() => {
-          return stage('horti.stage.postCleanup', 'Post-deploy cleanup, installation complete')
-            .then(() => {
-              return postCleanup(ddocWrapper(ddoc, mode), deployDoc);
-            });
-        });
+        .then(performDeploy(mode, deployDoc, ddoc, firstRun))
+        .then(stage('horti.stage.postCleanup', 'Post-deploy cleanup, installation complete'))
+        .then(postCleanup(ddocWrapper(ddoc, mode), deployDoc));
     });
 };
 

--- a/tests/daemon.js
+++ b/tests/daemon.js
@@ -38,7 +38,6 @@ describe('Daemon', () => {
       });
 
       const mode = 'mode';
-      const apps = 'apps';
       const firstRun = 'firstRun';
       const deployResult = Promise.resolve();
 
@@ -50,25 +49,25 @@ describe('Daemon', () => {
         install.install.returns(deployResult);
 
         const deployDoc = {};
-        daemon._performDeployment(deployDoc, mode, apps, firstRun)
+        daemon._performDeployment(deployDoc, mode, firstRun)
           .should.equal(deployResult);
 
-        install.install.args[0].should.deep.equal([deployDoc, mode, apps, firstRun]);
+        install.install.args[0].should.deep.equal([deployDoc, mode, firstRun]);
       });
       it('installs with the install action', () => {
         install.install.returns(deployResult);
 
         const deployDoc = {action: 'install'};
-        daemon._performDeployment(deployDoc, mode, apps, firstRun)
+        daemon._performDeployment(deployDoc, mode, firstRun)
           .should.equal(deployResult);
 
-        install.install.args[0].should.deep.equal([deployDoc, mode, apps, firstRun]);
+        install.install.args[0].should.deep.equal([deployDoc, mode, firstRun]);
       });
       it('stages with the stage action', () => {
         install.stage.returns(deployResult);
 
         const deployDoc = {action: 'stage'};
-        daemon._performDeployment(deployDoc, mode, apps, firstRun)
+        daemon._performDeployment(deployDoc, mode, firstRun)
           .should.equal(deployResult);
 
         install.stage.args[0].should.deep.equal([deployDoc]);
@@ -77,10 +76,10 @@ describe('Daemon', () => {
         install.complete.returns(deployResult);
 
         const deployDoc = {action: 'complete'};
-        daemon._performDeployment(deployDoc, mode, apps, firstRun)
+        daemon._performDeployment(deployDoc, mode, firstRun)
           .should.equal(deployResult);
 
-        install.complete.args[0].should.deep.equal([deployDoc, mode, apps, firstRun]);
+        install.complete.args[0].should.deep.equal([deployDoc, mode, firstRun]);
       });
     });
   });

--- a/tests/install.js
+++ b/tests/install.js
@@ -293,12 +293,16 @@ describe('Installation flow', () => {
   });
 
   describe('Post cleanup', () => {
+    const steps = deploySteps(null, null, deployDoc);
+
     it('deletes docs used in deploy', () => {
       DB.app.put.resolves();
       DB.app.allDocs.resolves({rows: [{id: 'foo', value: {rev: '1-bar'}}]});
       DB.app.bulkDocs.resolves([]);
       DB.app.viewCleanup.resolves();
-      return install._postCleanup(deployDoc)
+      sinon.stub(steps, 'removeOldVersion').resolves();
+
+      return install._postCleanup(steps, [], deployDoc)
         .then(() => {
           DB.app.put.callCount.should.equal(1);
           DB.app.put.args[0][0]._id.should.equal('horti-upgrade');
@@ -311,6 +315,7 @@ describe('Installation flow', () => {
             _deleted: true
           }]);
           DB.app.viewCleanup.callCount.should.equal(1);
+          steps.removeOldVersion.callCount.should.equal(1);
         });
     });
   });


### PR DESCRIPTION
The process from stopping to starting should really just be:

Stop processes
Move staged ddocs into production locations
Change symlink from old node_module locations to new ones
Start processes

medic/medic-webapp#4568