### PR TITLE
Add pre-boot checks

### DIFF
--- a/src/checks.js
+++ b/src/checks.js
@@ -1,0 +1,23 @@
+const dbs = require('./dbs');
+const { debug } = require('./log');
+
+const appDbOnline = () => dbs.app.info().catch(() => { throw Error('Cannot locate app db'); });
+
+const appDbMustBeCouchDB2 = () => {
+  return dbs.activeTasks()
+    .catch(() => {
+      // _active_tasks is currently required by horti and was added in 2.x
+      throw Error('Horticulturalist requires the application server you wish to deploy on to be CouchDB v2');
+    });
+};
+
+//
+// NB: we are intentionally not checking to see if the builds server is
+// accessible at start-up. It is a valid option to run Horti offline!
+//
+module.exports = () => {
+  debug('Running pre-boot checks');
+  return appDbOnline()
+    .then(appDbMustBeCouchDB2)
+    .then(() => debug('Pre-boot checks OK'));
+};

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,13 @@ const { error, info } = require('./log');
 
 const { ACTIONS } = require('./constants');
 
-const daemon = require('./daemon'),
+const apps = require('./apps'),
       bootstrap = require('./bootstrap'),
+      checks = require('./checks'),
+      daemon = require('./daemon'),
       fatality = require('./fatality'),
       help = require('./help'),
       lockfile = require('./lockfile'),
-      apps = require('./apps'),
       packageUtils = require('./package');
 
 const MODES = {
@@ -135,10 +136,10 @@ onExit((code) => {
 });
 
 lockfile.wait()
+  .then(() => info(`Starting Horticulturalist ${require('../package.json').version} ${mode.daemon ? 'daemon ' : ''}in ${mode.name} mode`))
+  .then(checks)
   .then(() => {
     fs.mkdirs(mode.deployments);
-
-    info(`Starting Horticulturalist ${require('../package.json').version} ${mode.daemon ? 'daemon ' : ''}in ${mode.name} mode`);
 
     if (action === ACTIONS.INSTALL) {
       return bootstrap.install(version);


### PR DESCRIPTION
Some checks to create clear up-front errors if the app db is
inaccessible or is not CouchDB 2.x compatible.