### PR TITLE
Disables view warming

### DIFF
--- a/src/install/index.js
+++ b/src/install/index.js
@@ -224,7 +224,9 @@ const predeploySteps = (deployDoc) => {
     .then(() => stage('horti.stage.extractingDdocs', 'Extracting ddocs'))
     .then(() => extractDdocs(ddoc))
     .then(() => stage('horti.stage.warmingViews', 'Warming views'))
-    .then(() => warmViews(deployDoc))
+    // View warming is temporarily disabled because timeouts are not correctly caught
+    // https://github.com/medic/medic-webapp/issues/4893
+    //.then(() => warmViews(deployDoc))
     .then(() => stage('horti.stage.readyToDeploy', 'View warming complete, ready to deploy'))
     .then(() => ddoc);
 };


### PR DESCRIPTION
Quick patch because this is blocking upgrading the instance meant to host 3.0 performance tests,
pending an upgrade that deals with view warming timeouts differently. 

medic/medic-webapp#4893
