### PR TITLE
"Offline Sync" mode for Horticulturalist

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Pick one mode to run in:
     --medic-os
         Only of interest to those who deploy using MedicOS. Deploys apps using
         the MedicOS daemon.
+    --satellite
+        Only of interest to those who deploy on Medic Satellite servers. Deploy
+        blindly from CouchDB. Cannot be used with specific deploy actions.
 
 You can also specify a deployment action to perform:
 

--- a/src/apps.js
+++ b/src/apps.js
@@ -1,8 +1,6 @@
 const child_process = require('child_process');
 const debug = require('./log').debug;
 
-const APPS = [ 'medic-api', 'medic-sentinel' ];
-
 const execForApp = (cmd, app) => {
   cmd = cmd.map(sub => sub.replace(/{{app}}/g, app));
 
@@ -15,31 +13,30 @@ const execForApp = (cmd, app) => {
   });
 };
 
-const startApps = (cmd) =>
-  APPS.reduce(
-      (p, app) => p
-        .then(() => debug(`Starting app: ${app} with command: ${cmd}…`))
-        .then(() => execForApp(cmd, app))
-        .then(() => debug(`Started ${app} in the background.`)),
-      Promise.resolve());
+const startApps = (cmd, apps) =>
+  apps.reduce(
+    (p, app) => p
+      .then(() => debug(`Starting app: ${app} with command: ${cmd}…`))
+      .then(() => execForApp(cmd, app))
+      .then(() => debug(`Started ${app} in the background.`)),
+    Promise.resolve());
 
-const stopApps = (cmd) =>
-  APPS.reduce(
-      (p, app) => p
-        .then(() => debug(`Stopping app: ${app} with command: ${cmd}…`))
-        .then(() => execForApp(cmd, app))
-        .then(() => debug(`Stopped ${app}.`)),
-      Promise.resolve());
+const stopApps = (cmd, apps) =>
+  apps.reduce(
+    (p, app) => p
+      .then(() => debug(`Stopping app: ${app} with command: ${cmd}…`))
+      .then(() => execForApp(cmd, app))
+      .then(() => debug(`Stopped ${app}.`)),
+    Promise.resolve());
 
-const stopSync = (cmd) => {
-  APPS.forEach(app => {
+const stopSync = (cmd, apps) => {
+  apps.forEach(app => {
     execForApp(cmd, app);
   });
 };
 
 module.exports = {
-  APPS: APPS,
-  start: (cmd) => startApps(cmd),
-  stop: (cmd) => stopApps(cmd),
-  stopSync: (cmd) => stopSync(cmd),
+  start: startApps,
+  stop: stopApps,
+  stopSync: stopSync,
 };

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -8,8 +8,8 @@ const {
   ACTIONS
 } = require('./constants');
 
-const getUpgradeDoc = () => {
-  return DB.app.get(HORTI_UPGRADE_DOC)
+const getUpgradeDoc = (upgradeDocument = HORTI_UPGRADE_DOC) => {
+  return DB.app.get(upgradeDocument)
     .catch(err => {
       if (err.status !== 404) {
         throw err;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,7 @@
 module.exports = {
   LEGACY_0_8_UPGRADE_DOC: '_design/medic:staged',
   HORTI_UPGRADE_DOC: 'horti-upgrade',
+  APPS: [ 'medic-api', 'medic-sentinel' ],
   ACTIONS: {
     // A complete installation from start to finish. End result is a deleted
     // HORTI_UPGRADE_DOC and the system running on the new version.

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -12,10 +12,10 @@ const DB = require('./dbs'),
       fatality = require('./fatality');
 
 const newDeployment = deployDoc =>
-  !!deployDoc &&
-  deployDoc._id === HORTI_UPGRADE_DOC &&
-  (deployDoc.action !== ACTIONS.STAGE || !deployDoc.staging_complete);
-
+      !!deployDoc &&
+      deployDoc._id === HORTI_UPGRADE_DOC &&
+      (deployDoc.action !== ACTIONS.STAGE || !deployDoc.staging_complete);
+      
 const performDeployment = (deployDoc, mode, firstRun=false) => {
   let deployAction;
 
@@ -33,7 +33,6 @@ const performDeployment = (deployDoc, mode, firstRun=false) => {
 const watchForDeployments = (mode) => {
   info('Watching for deployments');
 
-  /* Here we should watch the attachment itself somehow? */
   const watch = DB.app.changes({
     live: true,
     since: 'now',
@@ -103,7 +102,7 @@ module.exports = {
     let bootActions = Promise.resolve();
 
     if (mode.manageAppLifecycle && mode.daemon) {
-      bootActions = bootActions.then(() => apps.start(mode.start, mode.appsToStart));
+      bootActions = bootActions.then(() => apps.start(mode.start, mode.appsToDeploy));
     }
 
     if (module.exports._newDeployment(deployDoc)) {

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -33,10 +33,11 @@ const performDeployment = (deployDoc, mode, firstRun=false) => {
 const watchForDeployments = (mode) => {
   info('Watching for deployments');
 
+  /* Here we should watch the attachment itself somehow? */
   const watch = DB.app.changes({
     live: true,
     since: 'now',
-    doc_ids: [ HORTI_UPGRADE_DOC, LEGACY_0_8_UPGRADE_DOC],
+    doc_ids: [ HORTI_UPGRADE_DOC, LEGACY_0_8_UPGRADE_DOC ],
     include_docs: true,
     timeout: false,
   });
@@ -61,6 +62,8 @@ const watchForDeployments = (mode) => {
       // Old builds had no schema_version. New builds should be blocked from
       // accidentally having no schema version by the builds server's
       // validate_doc_update function
+
+      /* Need to maybe do a more robust doc change here */
       if (!deployDoc.schema_version || deployDoc.schema_version === 1) {
         return module.exports._performDeployment(deployDoc, mode)
           .then(() => module.exports._watchForDeployments(mode))
@@ -100,7 +103,7 @@ module.exports = {
     let bootActions = Promise.resolve();
 
     if (mode.manageAppLifecycle && mode.daemon) {
-      bootActions = bootActions.then(() => apps.start(mode.start));
+      bootActions = bootActions.then(() => apps.start(mode.start, mode.appsToStart));
     }
 
     if (module.exports._newDeployment(deployDoc)) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,11 @@ const apps = require('./apps'),
       lockfile = require('./lockfile'),
       packageUtils = require('./package');
 
-const startTime = new Date().getTime();
 const modeDefaults = {
   appsToDeploy: APPS,
   stageDeployment: true,
   upgradeDocuments: [HORTI_UPGRADE_DOC, LEGACY_0_8_UPGRADE_DOC],
-  getWritableDeployDoc: doc => doc,
+  writeLocalDeployLog: false,
 };
 const MODES = {
   dev: {
@@ -63,14 +62,7 @@ const MODES = {
     appsToDeploy: ['medic-api'],
     upgradeDocuments: [`_design/medic`],
     stageDeployment: false,
-
-    // unstaged deployments are triggered by the ddoc and then track their deployment progress in a new document
-    getWritableDeployDoc: doc => ({
-      _id: `_local/upgrade-${startTime}`,
-      build_info: Object.assign({}, doc.build_info),
-      schema_version: doc.schema_version,
-    }),
-
+    writeLocalDeployLog: true,
     start: ['bin/svc-start', '/srv/software', '{{app}}'],
     stop: ['bin/svc-stop', '{{app}}'],
     manageAppLifecycle: true,
@@ -120,7 +112,7 @@ const action = argv.install             ? ACTIONS.INSTALL :
                argv['complete-install'] ? ACTIONS.COMPLETE :
                undefined;
 
-if (mode.name === 'satellite' && action) {
+if (selectedMode === 'satellite' && action) {
   error('Satellite mode cannot be used with specific actions.');
   process.exit(-1);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const apps = require('./apps'),
       lockfile = require('./lockfile'),
       packageUtils = require('./package');
 
+const startTime = new Date().getTime();
 const modeDefaults = {
   appsToDeploy: APPS,
   stageDeployment: true,
@@ -65,7 +66,7 @@ const MODES = {
 
     // unstaged deployments are triggered by the ddoc and then track their deployment progress in a new document
     getWritableDeployDoc: doc => ({
-      _id: `satellite-${os.hostname()}-upgrade`,
+      _id: `_local/upgrade-${startTime}`,
       build_info: Object.assign({}, doc.build_info),
       schema_version: doc.schema_version,
     }),

--- a/src/index.js
+++ b/src/index.js
@@ -77,16 +77,6 @@ const argv = parseArgs(process.argv, {
   }
 });
 
-if (argv.version || argv.v) {
-  help.outputVersion();
-  return;
-}
-
-if (argv.help || argv.h) {
-  help.outputHelp();
-  return;
-}
-
 const selectedMode = Object.keys(MODES).find(mode => argv[mode]);
 if (!selectedMode) {
   help.outputHelp();
@@ -95,6 +85,16 @@ if (!selectedMode) {
 }
 
 const mode = Object.assign(modeDefaults, MODES[selectedMode]);
+
+if (argv.version || argv.v) {
+  help.outputVersion();
+  return;
+}
+
+if (!mode || argv.help || argv.h) {
+  help.outputHelp();
+  return;
+}
 
 if (active(argv.install, argv.stage, argv['complete-install']).length > 1) {
   help.outputHelp();

--- a/src/install/deploySteps.js
+++ b/src/install/deploySteps.js
@@ -10,7 +10,7 @@ const utils = require('../utils');
 module.exports = (mode, deployDoc) => {
 
   const startApps = (mode) => {
-    info('Starting all apps…', apps.APPS);
+    info('Starting all apps…', mode.appsToStart);
     return apps.start(mode.start)
       .then(() => info('All apps started.'));
   };

--- a/src/install/deploySteps.js
+++ b/src/install/deploySteps.js
@@ -151,7 +151,7 @@ module.exports = (mode, deployDoc) => {
         }
       })
 
-      .then(() => mode.stageDeployment ? deployStagedDdocs() : undefined)
+      .then(() => mode.stageDeployment ? deployStagedDdocs() : Promise.resolve())
 
       .then(() => {
         if (deployCount) {

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -59,7 +59,7 @@ const extractDdocs = ddoc => {
   return utils.betterBulkDocs(compiledDocs);
 };
 
-const warmViews = (deployDoc, stagedViewsOnly = true) => {
+const warmViews = (deployDoc, stagedViewsOnly) => {
   let viewsWarmed = false;
   const writeProgress = () => {
     return DB.activeTasks()
@@ -235,9 +235,9 @@ const preCleanup = () => {
     });
 };
 
-const postCleanup = (ddocWrapper, deployDoc, cleanStagedDdocs = true) => {
+const postCleanup = (ddocWrapper, deployDoc, clearStagedDdocs = true) => {
   const steps = [ removeOldVersion(ddocWrapper)];
-  if (cleanStagedDdocs) {
+  if (clearStagedDdocs) {
     steps.push(clearStagedDdocs());
   }
 

--- a/tests/unit/install.js
+++ b/tests/unit/install.js
@@ -186,7 +186,7 @@ describe('Installation flow', () => {
       DB.app.put.resolves({});
       DB.activeTasks.resolves([relevantIndexer, irrelevantIndexer]);
 
-      return install._warmViews(deployDoc)
+      return install._warmViews(deployDoc, true)
         .then(() => {
         DB.app.query.callCount.should.equal(2);
         DB.app.query.args[0][0].should.equal(':staged:some-views/a_view');
@@ -288,7 +288,7 @@ describe('Installation flow', () => {
         return Promise.resolve();
       });
 
-      return install._warmViews(deployDoc).then(() => {
+      return install._warmViews(deployDoc, true).then(() => {
         DB.activeTasks.callCount.should.equal(5);
         DB.app.query.callCount.should.equal(5);
         utils.update.callCount.should.equal(7);
@@ -455,7 +455,7 @@ describe('Installation flow', () => {
         return Promise.resolve();
       });
 
-      return install._warmViews(deployDoc).then(() => {
+      return install._warmViews(deployDoc, true).then(() => {
         DB.activeTasks.callCount.should.equal(6);
         DB.app.query.callCount.should.equal(3);
         deployDocs.length.should.equal(8);


### PR DESCRIPTION
@SCdF I'm looking for early feedback on this approach.

Offline Sync scenarios would benefit from the following configuration in Horti:

1.  Only start `medic-api` service, not `medic-sentinel`.
1.  Don't write to any non-_local document in Couch.
1.  `Just Relax and trust CouchDB`. Deploy the `.tgz` that is already in place, don't attempt to download anything.
1.  View warming for the production views instead of `:staged:` views.

This addes the new `horti --satellite` mode, which:

1.  Watches `_design/medic` for changes instead of the `horti-upgrade` doc.
1.  Adds new `appsToDeploy` array into the mode, set to `['medic-api']` for satellite.
1.  Adds new flag `stagedDeployment` into the mode, set to false for only satellite. Avoids everything to do with staging docs, warming staged docs, etc.
1.  Writes the "update log" in `_local/update-UUID` per deployment.

I am also planning to:
1.  Stop all services when a new deployment is detected to avoid a vPrevious API serving with a vNext WebApp. This introduces a weird compatibility state which should be avoided.
1.  Add unit testing.
1.  Do some regression testing, since I'm pretty sure I broke something here...