### PR TITLE
Fixes postCleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "horticulturalist",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horticulturalist",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "A fancy gardener",
   "repository": "https://github.com/medic/horticulturalist",
   "license": "Apache-2.0",

--- a/src/install/ddocWrapper.js
+++ b/src/install/ddocWrapper.js
@@ -56,6 +56,7 @@ module.exports = (ddoc, mode) => {
     ddoc: ddoc,
     mode: mode,
     getChangedApps: () => getChangedApps(),
-    unzipChangedApps: (apps) => unzipChangedApps(apps)
+    unzipChangedApps: (apps) => unzipChangedApps(apps),
+    getApps: () => getApps()
   };
 };

--- a/src/install/ddocWrapper.js
+++ b/src/install/ddocWrapper.js
@@ -15,19 +15,25 @@ module.exports = (ddoc, mode) => {
 
   const appNotAlreadyUnzipped = app => !fs.existsSync(app.deployPath());
 
-  const getChangedApps = () => {
-    let changedApps = [];
+  const getApps = () => {
     if (ddoc.node_modules) {
       // Legacy Kanso data location
-      changedApps = ddoc.node_modules
-              .split(',')
-              .map(module => moduleToApp(module));
-    } else if (ddoc.build_info) {
-      // New horticulturalist layout
-      changedApps = ddoc.build_info.node_modules
-              .map(module => moduleToApp(module));
+      return ddoc.node_modules
+        .split(',')
+        .map(module => moduleToApp(module));
     }
 
+    if (ddoc.build_info) {
+      // New horticulturalist layout
+      return ddoc.build_info.node_modules
+        .map(module => moduleToApp(module));
+    }
+
+    return [];
+  };
+
+  const getChangedApps = () => {
+    let changedApps = getApps();
     debug(`Found ${JSON.stringify(changedApps)}`);
     changedApps = changedApps.filter(appNotAlreadyUnzipped);
     debug(`Apps that aren't unzipped: ${JSON.stringify(changedApps)}`);

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -207,7 +207,7 @@ const clearStagedDdocs = () => {
 };
 
 const removeOldVersion = ddoc => {
-  return Promise.all(ddoc.getChangedApps().map(app => {
+  return Promise.all(ddoc.getApps().map(app => {
     const oldPath = app.deployPath('old');
 
     if(fs.existsSync(oldPath)) {

--- a/tests/int/tests/medic-webapp.js
+++ b/tests/int/tests/medic-webapp.js
@@ -1,7 +1,8 @@
-// const assert = require('chai').assert;
+const assert = require('chai').assert;
 
 const dbUtils = require('../utils/db'),
-      hortiUtils = require('../utils/horti');
+      hortiUtils = require('../utils/horti'),
+      request = require('request-promise-native');
 
 const PROD_BUILD_URL = 'https://staging.dev.medicmobile.org/_couch/builds';
 
@@ -36,6 +37,57 @@ describe('Basic Medic-Webapp smoke test (v. slow tests!)', function() {
       .then(horti => horti.kill())
       .then(() => hortiUtils.start([ '--install=medic:medic:3.1.x', '--test' ], waitCondition))
       .then(horti => horti.kill());
+  });
+
+  it('should support --install-ing previously installed build', () => {
+    const ddocs = {};
+
+    return request({
+        url: PROD_BUILD_URL + '/_all_docs?keys=["medic:medic:3.0.x","medic:medic:3.1.x"]&include_docs=true',
+        json: true
+      })
+      .then(results => {
+        results.rows.forEach(row => ddocs[row.id] = row.doc);
+        return hortiUtils.start([ '--install=medic:medic:3.0.x', '--test' ], waitCondition);
+      })
+      .then(horti => {
+        return Promise
+          .all([
+            hortiUtils.getCurrentAppDir('medic-api'),
+            hortiUtils.getCurrentAppDir('medic-sentinel'),
+          ])
+          .then(folders => {
+            assert.equal(folders[0], hortiUtils.getDDocAppDigest('medic-api', ddocs['medic:medic:3.0.x']));
+            assert.equal(folders[1], hortiUtils.getDDocAppDigest('medic-sentinel', ddocs['medic:medic:3.0.x']));
+            horti.kill();
+          });
+      })
+      .then(() => hortiUtils.start([ '--install=medic:medic:3.1.x', '--test' ], waitCondition))
+      .then(horti => {
+        return Promise
+          .all([
+            hortiUtils.getCurrentAppDir('medic-api'),
+            hortiUtils.getCurrentAppDir('medic-sentinel'),
+          ])
+          .then(folders => {
+            assert.equal(folders[0], hortiUtils.getDDocAppDigest('medic-api', ddocs['medic:medic:3.1.x']));
+            assert.equal(folders[1], hortiUtils.getDDocAppDigest('medic-sentinel', ddocs['medic:medic:3.1.x']));
+            horti.kill();
+          });
+      })
+      .then(() => hortiUtils.start([ '--install=medic:medic:3.0.x', '--test' ], waitCondition))
+      .then(horti => {
+        return Promise
+          .all([
+            hortiUtils.getCurrentAppDir('medic-api'),
+            hortiUtils.getCurrentAppDir('medic-sentinel'),
+          ])
+          .then(folders => {
+            assert.equal(folders[0], hortiUtils.getDDocAppDigest('medic-api', ddocs['medic:medic:3.0.x']));
+            assert.equal(folders[1], hortiUtils.getDDocAppDigest('medic-sentinel', ddocs['medic:medic:3.0.x']));
+            horti.kill();
+          });
+      });
   });
 
   it('should start the daemon with no install without error', () => {

--- a/tests/int/tests/medic-webapp.js
+++ b/tests/int/tests/medic-webapp.js
@@ -33,23 +33,23 @@ describe('Basic Medic-Webapp smoke test (v. slow tests!)', function() {
 
   it('should --install two upgrades without error', () => {
     return hortiUtils
-      .start([ '--install=medic:medic:3.0.x', '--test' ], waitCondition)
+      .start([ '--install=medic:medic:3.0.0', '--test' ], waitCondition)
       .then(horti => horti.kill())
-      .then(() => hortiUtils.start([ '--install=medic:medic:3.1.x', '--test' ], waitCondition))
+      .then(() => hortiUtils.start([ '--install=medic:medic:3.1.0', '--test' ], waitCondition))
       .then(horti => horti.kill());
   });
 
   it('should support --install-ing previously installed build', () => {
-    const ddocs = {};
+    const buildDocs = {};
 
     const checkBuildApps = build => {
       assert.equal(
         hortiUtils.getCurrentAppDir('medic-api'),
-        hortiUtils.getDDocAppDigest('medic-api', ddocs[build])
+        hortiUtils.getDDocAppDigest('medic-api', buildDocs[build])
       );
       assert.equal(
         hortiUtils.getCurrentAppDir('medic-sentinel'),
-        hortiUtils.getDDocAppDigest('medic-sentinel', ddocs[build])
+        hortiUtils.getDDocAppDigest('medic-sentinel', buildDocs[build])
       );
 
       assert.equal(hortiUtils.oldAppLinkExists('medic-api'), false);
@@ -57,30 +57,30 @@ describe('Basic Medic-Webapp smoke test (v. slow tests!)', function() {
     };
 
     return request({
-        url: PROD_BUILD_URL + '/_all_docs?keys=["medic:medic:3.0.x","medic:medic:3.1.x"]&include_docs=true',
+        url: PROD_BUILD_URL + '/_all_docs?keys=["medic:medic:3.0.0","medic:medic:3.1.0"]&include_docs=true',
         json: true
       })
       .then(results => {
-        results.rows.forEach(row => ddocs[row.id] = row.doc);
-        return hortiUtils.start([ '--install=medic:medic:3.0.x', '--test' ], waitCondition);
+        results.rows.forEach(row => buildDocs[row.id] = row.doc);
+        return hortiUtils.start([ '--install=medic:medic:3.0.0', '--test' ], waitCondition);
       })
       .then(horti => {
-        checkBuildApps('medic:medic:3.0.x');
+        checkBuildApps('medic:medic:3.0.0');
         horti.kill();
       })
-      .then(() => hortiUtils.start([ '--install=medic:medic:3.1.x', '--test' ], waitCondition))
+      .then(() => hortiUtils.start([ '--install=medic:medic:3.1.0', '--test' ], waitCondition))
       .then(horti => {
-        checkBuildApps('medic:medic:3.1.x');
+        checkBuildApps('medic:medic:3.1.0');
         horti.kill();
       })
-      .then(() => hortiUtils.start([ '--install=medic:medic:3.0.x', '--test' ], waitCondition))
+      .then(() => hortiUtils.start([ '--install=medic:medic:3.0.0', '--test' ], waitCondition))
       .then(horti => {
-        checkBuildApps('medic:medic:3.0.x');
+        checkBuildApps('medic:medic:3.0.0');
         horti.kill();
       })
-      .then(() => hortiUtils.start([ '--install=medic:medic:3.0.x', '--test' ], waitCondition))
+      .then(() => hortiUtils.start([ '--install=medic:medic:3.0.0', '--test' ], waitCondition))
       .then(horti => {
-        checkBuildApps('medic:medic:3.0.x');
+        checkBuildApps('medic:medic:3.0.0');
         horti.kill();
       });
   });

--- a/tests/int/tests/medic-webapp.js
+++ b/tests/int/tests/medic-webapp.js
@@ -42,6 +42,20 @@ describe('Basic Medic-Webapp smoke test (v. slow tests!)', function() {
   it('should support --install-ing previously installed build', () => {
     const ddocs = {};
 
+    const checkBuildApps = build => {
+      assert.equal(
+        hortiUtils.getCurrentAppDir('medic-api'),
+        hortiUtils.getDDocAppDigest('medic-api', ddocs[build])
+      );
+      assert.equal(
+        hortiUtils.getCurrentAppDir('medic-sentinel'),
+        hortiUtils.getDDocAppDigest('medic-sentinel', ddocs[build])
+      );
+
+      assert.equal(hortiUtils.oldAppLinkExists('medic-api'), false);
+      assert.equal(hortiUtils.oldAppLinkExists('medic-sentinel'), false);
+    };
+
     return request({
         url: PROD_BUILD_URL + '/_all_docs?keys=["medic:medic:3.0.x","medic:medic:3.1.x"]&include_docs=true',
         json: true
@@ -51,42 +65,23 @@ describe('Basic Medic-Webapp smoke test (v. slow tests!)', function() {
         return hortiUtils.start([ '--install=medic:medic:3.0.x', '--test' ], waitCondition);
       })
       .then(horti => {
-        return Promise
-          .all([
-            hortiUtils.getCurrentAppDir('medic-api'),
-            hortiUtils.getCurrentAppDir('medic-sentinel'),
-          ])
-          .then(folders => {
-            assert.equal(folders[0], hortiUtils.getDDocAppDigest('medic-api', ddocs['medic:medic:3.0.x']));
-            assert.equal(folders[1], hortiUtils.getDDocAppDigest('medic-sentinel', ddocs['medic:medic:3.0.x']));
-            horti.kill();
-          });
+        checkBuildApps('medic:medic:3.0.x');
+        horti.kill();
       })
       .then(() => hortiUtils.start([ '--install=medic:medic:3.1.x', '--test' ], waitCondition))
       .then(horti => {
-        return Promise
-          .all([
-            hortiUtils.getCurrentAppDir('medic-api'),
-            hortiUtils.getCurrentAppDir('medic-sentinel'),
-          ])
-          .then(folders => {
-            assert.equal(folders[0], hortiUtils.getDDocAppDigest('medic-api', ddocs['medic:medic:3.1.x']));
-            assert.equal(folders[1], hortiUtils.getDDocAppDigest('medic-sentinel', ddocs['medic:medic:3.1.x']));
-            horti.kill();
-          });
+        checkBuildApps('medic:medic:3.1.x');
+        horti.kill();
       })
       .then(() => hortiUtils.start([ '--install=medic:medic:3.0.x', '--test' ], waitCondition))
       .then(horti => {
-        return Promise
-          .all([
-            hortiUtils.getCurrentAppDir('medic-api'),
-            hortiUtils.getCurrentAppDir('medic-sentinel'),
-          ])
-          .then(folders => {
-            assert.equal(folders[0], hortiUtils.getDDocAppDigest('medic-api', ddocs['medic:medic:3.0.x']));
-            assert.equal(folders[1], hortiUtils.getDDocAppDigest('medic-sentinel', ddocs['medic:medic:3.0.x']));
-            horti.kill();
-          });
+        checkBuildApps('medic:medic:3.0.x');
+        horti.kill();
+      })
+      .then(() => hortiUtils.start([ '--install=medic:medic:3.0.x', '--test' ], waitCondition))
+      .then(horti => {
+        checkBuildApps('medic:medic:3.0.x');
+        horti.kill();
       });
   });
 

--- a/tests/int/utils/horti.js
+++ b/tests/int/utils/horti.js
@@ -61,9 +61,8 @@ module.exports = {
     });
   },
   cleanWorkingDir: () => promisify(fs.remove)('./test-workspace'),
-  getCurrentAppDir: (app) => {
-    return promisify(fs.realpath)(`./test-workspace/deployments/${app}/current`).then(path.basename);
-  },
+  getCurrentAppDir: (app) => path.basename(fs.realpathSync(`./test-workspace/deployments/${app}/current`)),
+  oldAppLinkExists: (app) => fs.existsSync(`./test-workspace/deployments/${app}/old`),
   getDDocAppDigest: (app, ddoc) => {
     const attName = Object.keys(ddoc._attachments).find(attachment => attachment.indexOf(app) === 0);
     return attName && ddoc._attachments[attName].digest.replace(/\//g, '');

--- a/tests/int/utils/horti.js
+++ b/tests/int/utils/horti.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra'),
       { promisify } = require('util'),
-      { spawn } = require('child_process');
+      { spawn } = require('child_process'),
+      path = require('path');
 
 const { APP_URL, API_PORT, BUILDS_URL } = require('./constants');
 
@@ -59,5 +60,12 @@ module.exports = {
       });
     });
   },
-  cleanWorkingDir: () => promisify(fs.remove)('./test-workspace')
+  cleanWorkingDir: () => promisify(fs.remove)('./test-workspace'),
+  getCurrentAppDir: (app) => {
+    return promisify(fs.realpath)(`./test-workspace/deployments/${app}/current`).then(path.basename);
+  },
+  getDDocAppDigest: (app, ddoc) => {
+    const attName = Object.keys(ddoc._attachments).find(attachment => attachment.indexOf(app) === 0);
+    return attName && ddoc._attachments[attName].digest.replace(/\//g, '');
+  }
 };


### PR DESCRIPTION
During `postCleanup`, `removeOldVersion` would call `getChangedApps` to obtain the list of new apps whose old versions need to be removed, but `getChangedApps` only returned unzipped apps - always empty at this point, as the new apps were unzipped earlier on. 

medic/medic-webapp#5034