### PR TITLE
Default installation target is the latest release

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ const action = argv.install             ? ACTIONS.INSTALL :
 
 let version = argv.install || argv.stage;
 if (version === true) {
-  version = 'medic:medic:master';
+  version = '@medic:medic:release';
 }
 
 if (version) {


### PR DESCRIPTION
Now we have release versions we can default to something more stable than master