### PR TITLE
Stage docs from `medic.json` or `compiled.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "horticulturalist",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horticulturalist",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A fancy gardener",
   "repository": "https://github.com/medic/horticulturalist",
   "license": "Apache-2.0",

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -74,13 +74,16 @@ const downloadBuild = deployDoc => {
 };
 
 const extractDdocs = ddoc => {
-  if (!ddoc._attachments || !ddoc._attachments['ddocs/compiled.json']) {
+  const compiledDdocs = ddoc._attachments &&
+                        ddoc._attachments['ddocs/compiled.json'] ||
+                        ddoc._attachments['ddocs/medic.json'];
+
+  if (!compiledDdocs) {
     debug('No extra ddocs to extract');
     return;
   }
 
-  const compiledDocs =
-    JSON.parse(ddoc._attachments['ddocs/compiled.json'].data).docs;
+  const compiledDocs = JSON.parse(compiledDdocs.data).docs;
 
   compiledDocs.forEach(utils.stageDdoc);
 

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -75,8 +75,8 @@ const downloadBuild = deployDoc => {
 
 const extractDdocs = ddoc => {
   const compiledDdocs = ddoc._attachments &&
-                        ddoc._attachments['ddocs/compiled.json'] ||
-                        ddoc._attachments['ddocs/medic.json'];
+                        (ddoc._attachments['ddocs/compiled.json'] ||
+                         ddoc._attachments['ddocs/medic.json']);
 
   if (!compiledDdocs) {
     debug('No extra ddocs to extract');

--- a/tests/int/tests/bootstrap.js
+++ b/tests/int/tests/bootstrap.js
@@ -16,7 +16,7 @@ describe('Bootstrapping', () => {
       .then(() => hortiUtils.start([
         '--install=test:test-app-1:1.0.0',
         '--no-daemon',
-        '--test'], { waitUntil: true }))
+        '--test'], { waitUntil: true, log: true }))
       .then(() => dbUtils.appDb().get('_design/test-app-1'))
       .then(ddoc => {
         assert.equal(ddoc.deploy_info.user, 'horticulturalist cli');
@@ -29,7 +29,7 @@ describe('Bootstrapping', () => {
       .then(() => hortiUtils.start([
         '--install=@test:test-app-1:release',
         '--no-daemon',
-        '--test'], { waitUntil: true }))
+        '--test'], { waitUntil: true, log: true }))
       .then(() => dbUtils.appDb().get('_design/test-app-1'))
       .then(ddoc => {
         assert.equal(ddoc.deploy_info.user, 'horticulturalist cli');

--- a/tests/unit/install.js
+++ b/tests/unit/install.js
@@ -128,6 +128,26 @@ describe('Installation flow', () => {
         });
       });
     });
+
+    it('should work read ddocs from medic.json attachment', () => {
+      const newStagedMainDdoc = {
+        _id: '_design/:staged:medic',
+        _attachments: {
+          'ddocs/medic.json': {
+            data: Buffer.from(JSON.stringify(compiled))
+          }
+        }
+      };
+
+      DB.app.bulkDocs.resolves([]);
+
+      return install._extractDdocs(newStagedMainDdoc).then(() => {
+        DB.app.bulkDocs.callCount.should.equal(1);
+        DB.app.bulkDocs.args[0][0].should.deep.equal([{
+          _id: '_design/:staged:medic-test'
+        }, newStagedMainDdoc]);
+      });
+    });
   });
 
   describe('Warming views', () => {


### PR DESCRIPTION
This [commit](https://github.com/medic/cht-core/commit/67bb273e2d20b775b27a6c0bdf20b169284aff1d#diff-35b4a816e0441e6a375cd925af50752cR122) changes the name of the "main" attachment from `compiled.json` to `medic.json`. 
Ddocs are staged from either one of these attachments. 

medic/horticulturalist#57