### PR TITLE
Handle trying to install a package that does not exist

### DIFF
--- a/src/install/index.js
+++ b/src/install/index.js
@@ -57,7 +57,10 @@ const downloadBuild = deployDoc => {
     .catch(err => {
       if (err && err.status && err.status >= 400 && err.status < 500) {
         error(`Failed to download build for [${docKey}]. Aborting install.`);
-        return deleteDeployDoc(deployDoc).reject(err);
+        return deleteDeployDoc(deployDoc)
+          .then(() => {
+            throw err;
+          });
       }
       throw err;
     })

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -155,7 +155,7 @@ const postCleanup = (ddocWrapper, deployDoc) => {
         removeOldVersion(ddocWrapper),
         clearStagedDdocs()
       ])
-      .then(deleteDeployDoc(deployDoc))
+      .then(() => deleteDeployDoc(deployDoc))
       .then(() => {
         debug('Cleanup old views');
         return DB.app.viewCleanup();

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -55,7 +55,7 @@ const downloadBuild = deployDoc => {
   debug(`Downloading ${docKey}, this may take some time…`);
   return DB.builds.get(docKey, { attachments: true, binary: true })
     .catch(err => {
-      if (err && err.status === 404) {
+      if (err && err.status && err.status >= 400 && err.status < 500) {
         error(`Failed to find a build to download for [${docKey}]. Aborting install.`);
         return deleteDeployDoc(deployDoc).reject(err);
       }

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -57,10 +57,7 @@ const downloadBuild = deployDoc => {
     .catch(err => {
       if (err && err.status === 404) {
         error(`Failed to find a build to download for [${docKey}]. Aborting install.`);
-        return cleanupDeployDoc(deployDoc)
-          .then(() => {
-            throw err;
-          });
+        return cleanupDeployDoc(deployDoc).reject(err);
       }
       throw err;
     })

--- a/src/install/index.js
+++ b/src/install/index.js
@@ -56,7 +56,7 @@ const downloadBuild = deployDoc => {
   return DB.builds.get(docKey, { attachments: true, binary: true })
     .catch(err => {
       if (err && err.status && err.status >= 400 && err.status < 500) {
-        error(`Failed to find a build to download for [${docKey}]. Aborting install.`);
+        error(`Failed to download build for [${docKey}]. Aborting install.`);
         return deleteDeployDoc(deployDoc).reject(err);
       }
       throw err;

--- a/tests/unit/install.js
+++ b/tests/unit/install.js
@@ -96,8 +96,8 @@ describe('Installation flow', () => {
           actual._id.should.equal('horti-upgrade');
           actual._deleted.should.equal(true);
           actual.should.not.have.property('deploy_info');
-          DB.app.viewCleanup.callCount.should.equal(1);
 
+          DB.app.viewCleanup.callCount.should.equal(0);
           utilsGetStagedDdocs.callCount.should.equal(0);
           utilsUpdate.callCount.should.equal(0);
         });


### PR DESCRIPTION
I am working on https://github.com/medic/cht-core/issues/6602 and am thinking that the fix should be something like what I have in this PR.  However, I am honestly not even sure if I am trying to fix this at the properly level or if there is some other place/way that this issue should be addressed (particularly since the issue was logged to cht-core and not to the horticulturalist repo). So, just looking for some feedback on my  approach.

The problem from the issue is that someone tries to trigger an upgrade (via the `api/v1/upgrade` API) to a package that does not actually exist and then this causes the whole system to basically get stuck because it cannot complete the upgrade.

Now, the [API code for triggering the upgrade](https://github.com/medic/cht-core/blob/71d412f657c2d842f1f8955f87ea11ff8099fd04/api/src/controllers/upgrade.js#L6) does not validate the requested package is available before triggering the `horti-upgrade` doc to be written. So when the Horticulturalist daemon picks up the  `horti-upgrade` doc with the bad build_info, it just goes ahead and tries to retrieve the invalid build from the staging database. When that call returns a 404, [Horticulturalist just fails out and dies](https://github.com/medic/horticulturalist/blob/9a3031acf976ca7d809cd2cdab04a27c4115cb7a/src/daemon.js#L67).  However, the `horti-upgrade` doc gets left in the app database with the bad build_info, so any attempts to restart Horticulturalist without fixing the build_info will also fail.  

The changes I have here simply detect that a 404 was returned from the staging database and delete the `horti-upgrade` doc before exiting Horticulturalist (so that when Horticulturalist comes back up, it can restart successfully without trying to continue the failed upgrade).

Here are some more specific questions/alternatives that I am considering:

- We could validate the build_info in the API code before writing the initial `horti-upgrade` doc. But that would require a connection to the staging database from the API and an extra query for the build_info. Not sure if this approach would be preferable.
- In Horticulturalist, when we catch the 404 from the staging database, we could ignore the upgrade (like I have in this PR) and then gracefully continue without exiting the app. It seemed like for other errors we were intentionally exiting, so I followed that pattern, but it seems kind of weird to me to "handle" the error and then still exit.